### PR TITLE
Update pgmorl.py

### DIFF
--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -419,7 +419,6 @@ class PGMORL(MOAgent):
         th.backends.cudnn.deterministic = torch_deterministic
 
         # env setup
-        self.num_envs = num_envs
         if env is None:
             self.env = mo_gym.MOSyncVectorEnv(
                 # Video recording is disabled since broken for now
@@ -458,6 +457,20 @@ class PGMORL(MOAgent):
                 gamma=self.gamma,
                 device=self.device,
                 seed=self.seed,
+                steps_per_iteration = self.steps_per_iteration,
+                num_minibatches = self.num_minibatches,
+                update_epochs = self.update_epochs,
+                learning_rate = self.learning_rate,
+                anneal_lr = self.anneal_lr,
+                clip_coef = self.clip_coef,
+                ent_coef = self.ent_coef,
+                vf_coef = self.vf_coef,
+                clip_vloss = self.clip_vloss,
+                max_grad_norm = self.max_grad_norm,
+                norm_adv = self.norm_adv,
+                target_kl = self.target_kl,
+                gae = self.gae,
+                gae_lambda = self.gae_lambda,
             )
             for i in range(self.pop_size)
         ]


### PR DESCRIPTION
1. self.num_envs was defined already on line 369 (removed repeated declaration)
2. pass PGMORL params to MOPPO