### PR TITLE
add wandb.log feature to record episode log

### DIFF
--- a/morl_baselines/common/morl_algorithm.py
+++ b/morl_baselines/common/morl_algorithm.py
@@ -71,6 +71,14 @@ class MOPolicy(ABC):
                 discounted_vec_return[i],
                 self.global_step,
             )
+        log_dict = {
+            "train/step": self.global_step  
+            "train/scalarized_return": scalarized_return, 
+            "train/scalarized_discounted_return": scalarized_discounted_return, 
+            "train/vec_return": vec_return, 
+            "train/discounted_vec_return": discounted_vec_return
+        }
+        wandb.log(log_dict)
 
     def policy_eval(
         self,
@@ -223,6 +231,10 @@ class MOAgent(ABC):
         self.writer = SummaryWriter(f"/tmp/{self.experiment_name}")
         # The default "step" of wandb is not the actual time step (gloabl_step) of the MDP
         wandb.define_metric("*", step_metric="global_step")
+        #to save the step log in the folder "train"
+        wandb.define_metric("train/step")
+        # set all other train/ metrics to use this step
+        wandb.define_metric("train/*", step_metric="train/step")
 
     def close_wandb(self) -> None:
         """Closes the wandb writer and finishes the run."""


### PR DESCRIPTION
Description:

The current wandb log is recorded by the writer. It is not easy to extract data from the log text file.  To extend the usage for plot and 

Ref: https://docs.wandb.ai/guides/track/log

Change:
1. add `wandb.define_metric("train/step")`
2. create a `log_dict` in ` __report`
3. log each entry in wandb. `wandb.log(log_dict)`
