### PR TITLE
Feature/benchmarking scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install pytest
+        pip install moviepy
         pip install mujoco
         sudo apt-get install libgmp-dev
         pip install imageio

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ wandb/
 
 # Saved weights
 weights/
+
+# Saved videos
+videos/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        exclude: ^(tests/)|(docs/)|(setup.py)|(examples/)
+        exclude: ^(tests/)|(docs/)|(setup.py)|(examples/)|(benchmark/)
         args:
           - --source
           - --explain

--- a/benchmark/launch_experiment.py
+++ b/benchmark/launch_experiment.py
@@ -1,0 +1,90 @@
+import argparse
+
+import mo_gymnasium as mo_gym
+import numpy as np
+from mo_gymnasium.utils import MORecordEpisodeStatistics
+
+from morl_baselines.multi_policy.envelope.envelope import Envelope
+from morl_baselines.multi_policy.gpi_pd.gpi_pd import GPIPD
+from morl_baselines.multi_policy.gpi_pd.gpi_pd_continuous_action import (
+    GPIPDContinuousAction,
+)
+from morl_baselines.multi_policy.multi_policy_moqlearning.mp_mo_q_learning import (
+    MPMOQLearning,
+)
+from morl_baselines.multi_policy.pareto_q_learning.pql import PQL
+from morl_baselines.multi_policy.pcn.pcn import PCN
+from morl_baselines.multi_policy.pgmorl.pgmorl import PGMORL
+
+
+ALGOS = {
+    "pgmorl": PGMORL,
+    "envelope": Envelope,
+    "gpi_pd_continuous": GPIPDContinuousAction,
+    "gpi_pd_discrete": GPIPD,
+    "mpmoql": MPMOQLearning,
+    "pcn": PCN,
+    "pql": PQL,
+    "ols": MPMOQLearning,
+}
+
+ENVS_WITH_KNOWN_PARETO_FRONT = [
+    "deep-sea-treasure-concave-v0",
+    "deep-sea-treasure-v0",
+    "minecart-v0",
+    "resource-gathering-v0",
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--algo", type=str, help="Name of the algorithm to run", choices=ALGOS.keys())
+    parser.add_argument("--env-id", type=str, help="MO-Gymnasium id of the environment to run")
+    parser.add_argument("--num-timesteps", type=int, help="Number of timesteps to train for")
+    parser.add_argument("--gamma", type=float, help="Discount factor to apply to the environment and algorithm")
+    parser.add_argument("--ref-point", type=list, nargs="+", help="Reference point to use for the hypervolume calculation")
+    parser.add_argument("--seed", type=int, help="Random seed to use", default=42)
+    parser.add_argument("--wandb-entity", type=str, help="Wandb entity to use", required=False)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.algo != "pgmorl":
+        env = MORecordEpisodeStatistics(mo_gym.make(args.env_id), gamma=args.gamma)
+        eval_env = mo_gym.make(args.env_id)
+        algo = ALGOS[args.algo](
+            env=env,
+            gamma=args.gamma,
+            log=True,
+            seed=args.seed,
+            wandb_entity=args.wandb_entity,
+        )
+        if env.env_id in ENVS_WITH_KNOWN_PARETO_FRONT:
+            known_pareto_front = env.unwrapped.pareto_front(gamma=args.gamma)
+        else:
+            known_pareto_front = None
+
+        algo.train(
+            total_timesteps=args.num_timesteps,
+            eval_env=eval_env,
+            ref_point=np.array(args.ref_point),
+            known_pareto_front=known_pareto_front,
+        )
+
+    else:
+        # PGMORL creates its own environments because it requires wrappers
+        algo = ALGOS[args.algo](
+            env_id=args.env_id,
+            ref_point=np.array(args.ref_point),
+            gamma=args.gamma,
+            log=True,
+            seed=args.seed,
+            wandb_entity=args.wandb_entity,
+        )
+        algo.train(total_timesteps=args.num_timesteps)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/launch_experiment.py
+++ b/benchmark/launch_experiment.py
@@ -163,31 +163,6 @@ def main():
             wandb_entity=args.wandb_entity,
         )
         algo.train(total_timesteps=args.num_timesteps)
-    elif args.algo == "pql":
-        env = MORecordEpisodeStatistics(mo_gym.make(args.env_id), gamma=args.gamma)
-        print(f"Instantiating {args.algo} on {args.env_id}")
-        algo = ALGOS[args.algo](
-            env=env,
-            ref_point=np.array(args.ref_point),
-            gamma=args.gamma,
-            log=True,
-            seed=args.seed,
-            wandb_entity=args.wandb_entity,
-            **args.init_hyperparams,
-        )
-        if args.env_id in ENVS_WITH_KNOWN_PARETO_FRONT:
-            known_pareto_front = env.unwrapped.pareto_front(gamma=args.gamma)
-        else:
-            known_pareto_front = None
-
-        print(algo.get_config())
-
-        print("Training starts... Let's roll!")
-        algo.train(
-            total_timesteps=args.num_timesteps,
-            known_pareto_front=known_pareto_front,
-            **args.train_hyperparams,
-        )
 
     else:
         env = MORecordEpisodeStatistics(mo_gym.make(args.env_id), gamma=args.gamma)

--- a/benchmark/launch_experiment.py
+++ b/benchmark/launch_experiment.py
@@ -154,6 +154,7 @@ def main():
 
     if args.algo == "pgmorl":
         # PGMORL creates its own environments because it requires wrappers
+        print(f"Instantiating {args.algo} on {args.env_id}")
         algo = ALGOS[args.algo](
             env_id=args.env_id,
             origin=np.array(args.ref_point),
@@ -161,8 +162,17 @@ def main():
             log=True,
             seed=args.seed,
             wandb_entity=args.wandb_entity,
+            **args.init_hyperparams,
         )
-        algo.train(total_timesteps=args.num_timesteps)
+        print(algo.get_config())
+
+        print("Training starts... Let's roll!")
+        algo.train(
+            total_timesteps=args.num_timesteps,
+            ref_point=np.array(args.ref_point),
+            known_pareto_front=None,
+            **args.train_hyperparams,
+        )
 
     else:
         env = MORecordEpisodeStatistics(mo_gym.make(args.env_id), gamma=args.gamma)

--- a/benchmark/launch_experiment.py
+++ b/benchmark/launch_experiment.py
@@ -42,11 +42,13 @@ ENVS_WITH_KNOWN_PARETO_FRONT = [
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--algo", type=str, help="Name of the algorithm to run", choices=ALGOS.keys())
-    parser.add_argument("--env-id", type=str, help="MO-Gymnasium id of the environment to run")
-    parser.add_argument("--num-timesteps", type=int, help="Number of timesteps to train for")
-    parser.add_argument("--gamma", type=float, help="Discount factor to apply to the environment and algorithm")
-    parser.add_argument("--ref-point", type=list, nargs="+", help="Reference point to use for the hypervolume calculation")
+    parser.add_argument("--algo", type=str, help="Name of the algorithm to run", choices=ALGOS.keys(), required=True)
+    parser.add_argument("--env-id", type=str, help="MO-Gymnasium id of the environment to run", required=True)
+    parser.add_argument("--num-timesteps", type=int, help="Number of timesteps to train for", required=True)
+    parser.add_argument("--gamma", type=float, help="Discount factor to apply to the environment and algorithm", required=True)
+    parser.add_argument(
+        "--ref-point", type=float, nargs="+", help="Reference point to use for the hypervolume calculation", required=True
+    )
     parser.add_argument("--seed", type=int, help="Random seed to use", default=42)
     parser.add_argument("--wandb-entity", type=str, help="Wandb entity to use", required=False)
     parser.add_argument(
@@ -91,6 +93,7 @@ def autotag() -> str:
 
 def main():
     args = parse_args()
+    print(args)
 
     if args.auto_tag:
         if "WANDB_TAGS" in os.environ:
@@ -112,7 +115,7 @@ def main():
             seed=args.seed,
             wandb_entity=args.wandb_entity,
         )
-        if env.env_id in ENVS_WITH_KNOWN_PARETO_FRONT:
+        if args.env_id in ENVS_WITH_KNOWN_PARETO_FRONT:
             known_pareto_front = env.unwrapped.pareto_front(gamma=args.gamma)
         else:
             known_pareto_front = None

--- a/benchmark/launch_experiment.py
+++ b/benchmark/launch_experiment.py
@@ -156,7 +156,7 @@ def main():
         # PGMORL creates its own environments because it requires wrappers
         algo = ALGOS[args.algo](
             env_id=args.env_id,
-            ref_point=np.array(args.ref_point),
+            origin=np.array(args.ref_point),
             gamma=args.gamma,
             log=True,
             seed=args.seed,

--- a/docs/algos/performances.md
+++ b/docs/algos/performances.md
@@ -30,7 +30,14 @@ Here is the function that logs all the metrics:
 
 ## Storage
 
-All the metrics will be reported to wandb to allow for easy manipulation and exporting of the data.
+Our official performance metrics are sent to [openrlbenchmark](https://wandb.ai/openrlbenchmark/MORL-Baselines) on wandb. From there, it is possible to use [openrlbenchmark API](https://github.com/openrlbenchmark/openrlbenchmark) to query and plot the wanted results for paper format. Life is good when the full flow is automated 🥸.
+
+## Benchmarking script
+It is possible to run algorithms from a CLI and configure the parameters accordingly. The script is located in `benchmark/launch_experiment.py`. Here is the documentation:
+```{eval-rst}
+.. automodule:: benchmark.launch_experiment
+    :members:
+```
 
 ## Algorithms
 

--- a/examples/gpi_pd_hopper.py
+++ b/examples/gpi_pd_hopper.py
@@ -42,11 +42,11 @@ def main(algo: str, gpi_pd: bool, g: int, timesteps_per_iter: int = 15000):
     )
 
     agent.train(
+        total_timesteps=10 * timesteps_per_iter,
         eval_env=eval_env,
         ref_point=np.array([-100.0, -100.0]),
         known_pareto_front=None,
         weight_selection_algo=algo,
-        max_iter=10,
         timesteps_per_iter=timesteps_per_iter,
     )
 

--- a/examples/gpi_pd_minecart.py
+++ b/examples/gpi_pd_minecart.py
@@ -54,11 +54,11 @@ def main(algo: str, gpi_pd: bool, g: int, timesteps_per_iter: int = 10000, seed:
     )
 
     agent.train(
+        total_timesteps=15 * timesteps_per_iter,
         eval_env=eval_env,
         ref_point=np.array([0.0, 0.0, -200.0]),
         known_pareto_front=env.unwrapped.pareto_front(gamma=0.98),
         weight_selection_algo=algo,
-        max_iter=15,
         timesteps_per_iter=timesteps_per_iter,
     )
 

--- a/examples/mp_mo_q_learning_DST.py
+++ b/examples/mp_mo_q_learning_DST.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
         epsilon_ols=0.0,
     )
     mp_moql.train(
-        num_iterations=15,
+        total_timesteps=15 * int(2e5),
         timesteps_per_iteration=int(2e5),
         eval_freq=100,
         num_episodes_eval=1,

--- a/examples/ols_dst.py
+++ b/examples/ols_dst.py
@@ -27,13 +27,13 @@ def main():
         epsilon_ols=0.0,
     )
     mp_moql.train(
-        num_iterations=15,
-        timesteps_per_iteration=int(2e5),
-        eval_freq=100,
-        num_episodes_eval=1,
+        total_timesteps=15 * int(2e5),
         eval_env=eval_env,
         ref_point=np.array([0.0, -25.0]),
         known_pareto_front=env.unwrapped.pareto_front(gamma=GAMMA),
+        timesteps_per_iteration=int(2e5),
+        eval_freq=100,
+        num_episodes_eval=1,
     )
 
 

--- a/examples/pcn_minecart.py
+++ b/examples/pcn_minecart.py
@@ -24,13 +24,12 @@ def main():
     )
 
     agent.train(
-        env,
+        total_timesteps=int(1e7),
+        ref_point=np.array([0, 0, -200.0]),
         num_er_episodes=20,
         max_buffer_size=50,
         num_model_updates=50,
-        total_time_steps=int(1e7),
         max_return=np.array([1.5, 1.5, -0.0]),
-        ref_point=np.array([0, 0, -200.0]),
         known_pareto_front=env.unwrapped.pareto_front(gamma=1.0),
     )
 

--- a/examples/pgmorl_halfcheetah.py
+++ b/examples/pgmorl_halfcheetah.py
@@ -9,16 +9,17 @@ if __name__ == "__main__":
     env_id = "mo-halfcheetah-v4"
     algo = PGMORL(
         env_id=env_id,
-        ref_point=np.array([0.0, -5.0]),
-        known_pareto_front=None,
         num_envs=4,
         pop_size=6,
         warmup_iterations=80,
         evolutionary_iterations=20,
         num_weight_candidates=7,
-        limit_env_steps=int(5e6),
     )
-    algo.train()
+    algo.train(
+        total_timesteps=int(5e6),
+        ref_point=np.array([0.0, -5.0]),
+        known_pareto_front=None,
+    )
     env = make_env(env_id, 422, 1, "PGMORL_test", gamma=0.995)()  # idx != 0 to avoid taking videos
 
     # Execution of trained policies

--- a/examples/pql_dst.py
+++ b/examples/pql_dst.py
@@ -21,9 +21,8 @@ if __name__ == "__main__":
         log=True,
     )
 
-    num_episodes = 10000
     pf = agent.train(
-        num_episodes=10000,
+        total_timesteps=10000,
         log_every=100,
         action_eval="hypervolume",
         known_pareto_front=env.pareto_front(gamma=0.99),

--- a/morl_baselines/common/morl_algorithm.py
+++ b/morl_baselines/common/morl_algorithm.py
@@ -1,4 +1,5 @@
 """MORL algorithm base classes."""
+import time
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 
@@ -170,6 +171,7 @@ class MOAgent(ABC):
 
         self.global_step = 0
         self.num_episodes = 0
+        self.seed = None
 
     def extract_env_info(self, env: Optional[gym.Env]) -> None:
         """Extracts all the features of the environment: observation space, action space, ...
@@ -205,25 +207,28 @@ class MOAgent(ABC):
             dict: Config
         """
 
-    def setup_wandb(self, project_name: str, experiment_name: str) -> None:
+    def setup_wandb(self, project_name: str, experiment_name: str, entity: Optional[str] = None) -> None:
         """Initializes the wandb writer.
 
         Args:
             project_name: name of the wandb project. Usually MORL-Baselines.
             experiment_name: name of the wandb experiment. Usually the algorithm name.
+            entity: wandb entity. Usually your username but useful for reporting other places such as openrlbenmark.
 
         Returns:
             None
         """
         self.experiment_name = experiment_name
+        self.full_experiment_name = f"{self.env.spec.id}__{experiment_name}__{self.seed}__{int(time.time())}"
         import wandb
 
         wandb.init(
             project=project_name,
+            entity=entity,
             sync_tensorboard=True,
             config=self.get_config(),
-            name=self.experiment_name,
-            monitor_gym=False,
+            name=self.full_experiment_name,
+            monitor_gym=True,
             save_code=True,
         )
         self.writer = SummaryWriter(f"/tmp/{self.experiment_name}")

--- a/morl_baselines/common/morl_algorithm.py
+++ b/morl_baselines/common/morl_algorithm.py
@@ -1,7 +1,7 @@
 """MORL algorithm base classes."""
 import time
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import Dict, Optional, Union
 
 import gymnasium as gym
 import numpy as np
@@ -208,15 +208,14 @@ class MOAgent(ABC):
             dict: Config
         """
 
-    def register_additional_config(self, ref_point: np.ndarray, known_front: Optional[List[np.ndarray]]) -> None:
+    def register_additional_config(self, conf: Dict = {}) -> None:
         """Registers additional config parameters to wandb. For example when calling train().
 
         Args:
-            ref_point: reference point used for the scalarization
-            known_front: known pareto front
+            conf: dictionary of additional config parameters
         """
-        wandb.config["ref_point"] = ref_point.tolist()
-        wandb.config["known_front"] = known_front
+        for key, value in conf.items():
+            wandb.config[key] = value
 
     def setup_wandb(self, project_name: str, experiment_name: str, entity: Optional[str] = None) -> None:
         """Initializes the wandb writer.

--- a/morl_baselines/common/utils.py
+++ b/morl_baselines/common/utils.py
@@ -1,4 +1,6 @@
 """General utils for the MORL baselines."""
+import os
+import random
 from typing import Iterable, List, Optional
 
 import numpy as np
@@ -299,3 +301,18 @@ def make_gif(env, agent, weight: np.ndarray, fullpath: str, fps: int = 50, lengt
     clip = ImageSequenceClip(list(frames), fps=fps)
     clip.write_gif(fullpath + ".gif", fps=fps)
     print("Saved gif at: " + fullpath + ".gif")
+
+
+def seed_everything(seed: int):
+    """Set random seeds for reproducibility.
+
+    Args:
+        seed: random seed
+    """
+    random.seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    np.random.seed(seed)
+    th.manual_seed(seed)
+    th.cuda.manual_seed(seed)
+    th.backends.cudnn.deterministic = True
+    th.backends.cudnn.benchmark = True

--- a/morl_baselines/common/utils.py
+++ b/morl_baselines/common/utils.py
@@ -114,6 +114,21 @@ def linearly_decaying_value(initial_value, decay_period, step, warmup_steps, fin
     return value
 
 
+def unique_tol(a: List[np.ndarray], tol=1e-4) -> List[np.ndarray]:
+    """Returns unique elements of a list of np.arrays, within a tolerance."""
+    if len(a) == 0:
+        return a
+    delete = np.array([False] * len(a))
+    a = np.array(a)
+    for i in range(len(a)):
+        if delete[i]:
+            continue
+        for j in range(i + 1, len(a)):
+            if np.allclose(a[i], a[j], tol):
+                delete[j] = True
+    return list(a[~delete])
+
+
 def extrema_weights(dim: int) -> List[np.ndarray]:
     """Generate weight vectors in the extrema of the weight simplex. That is, one element is 1 and the rest are 0.
 

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -488,7 +488,7 @@ class Envelope(MOPolicy, MOAgent):
         if eval_env is not None:
             assert ref_point is not None, "Reference point must be provided for the hypervolume computation."
         if self.log:
-            self.register_additional_config(ref_point, known_pareto_front)
+            self.register_additional_config({"ref_point": ref_point.tolist(), "known_front": known_pareto_front})
 
         self.global_step = 0 if reset_num_timesteps else self.global_step
         self.num_episodes = 0 if reset_num_timesteps else self.num_episodes

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -461,12 +461,12 @@ class Envelope(MOPolicy, MOAgent):
     def train(
         self,
         total_timesteps: int,
-        weight: Optional[np.ndarray] = None,
-        total_episodes: Optional[int] = None,
-        reset_num_timesteps: bool = True,
         eval_env: Optional[gym.Env] = None,
         ref_point: Optional[np.ndarray] = None,
         known_pareto_front: Optional[List[np.ndarray]] = None,
+        weight: Optional[np.ndarray] = None,
+        total_episodes: Optional[int] = None,
+        reset_num_timesteps: bool = True,
         eval_freq: int = 1000,
         eval_weights_number_for_front: int = 100,
         reset_learning_starts: bool = False,
@@ -475,12 +475,12 @@ class Envelope(MOPolicy, MOAgent):
 
         Args:
             total_timesteps: total number of timesteps to train for.
-            weight: weight vector. If None, it is randomly sampled every episode (as done in the paper).
-            total_episodes: total number of episodes to train for. If None, it is ignored.
-            reset_num_timesteps: whether to reset the number of timesteps. Useful when training multiple times.
             eval_env: environment to use for evaluation. If None, it is ignored.
             ref_point: reference point for the hypervolume computation.
             known_pareto_front: known pareto front for the hypervolume computation.
+            weight: weight vector. If None, it is randomly sampled every episode (as done in the paper).
+            total_episodes: total number of episodes to train for. If None, it is ignored.
+            reset_num_timesteps: whether to reset the number of timesteps. Useful when training multiple times.
             eval_freq: policy evaluation frequency.
             eval_weights_number_for_front: number of weights to sample for creating the pareto front when evaluating.
             reset_learning_starts: whether to reset the learning starts. Useful when training multiple times.

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -23,6 +23,7 @@ from morl_baselines.common.utils import (
     log_episode_info,
     polyak_update,
     random_weights,
+    seed_everything,
 )
 
 
@@ -192,8 +193,7 @@ class Envelope(MOPolicy, MOAgent):
 
         self.seed = seed
         if self.seed is not None:
-            th.manual_seed(self.seed)
-            np.random.seed(self.seed)
+            seed_everything(self.seed)
         self.log = log
         if log:
             self.setup_wandb(project_name, experiment_name, wandb_entity)

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -487,6 +487,7 @@ class Envelope(MOPolicy, MOAgent):
         """
         if eval_env is not None:
             assert ref_point is not None, "Reference point must be provided for the hypervolume computation."
+        if self.log:
             self.register_additional_config(ref_point, known_pareto_front)
 
         self.global_step = 0 if reset_num_timesteps else self.global_step

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -104,7 +104,9 @@ class Envelope(MOPolicy, MOAgent):
         homotopy_decay_steps: int = None,
         project_name: str = "MORL-Baselines",
         experiment_name: str = "Envelope",
+        wandb_entity: Optional[str] = None,
         log: bool = True,
+        seed: Optional[int] = None,
         device: Union[th.device, str] = "auto",
     ):
         """Envelope Q-learning algorithm.
@@ -133,7 +135,9 @@ class Envelope(MOPolicy, MOAgent):
             homotopy_decay_steps: The number of steps to decay the homotopy parameter over.
             project_name: The name of the project, for wandb logging.
             experiment_name: The name of the experiment, for wandb logging.
+            wandb_entity: The entity of the project, for wandb logging.
             log: Whether to log to wandb.
+            seed: The seed for the random number generator.
             device: The device to use for training.
         """
         MOAgent.__init__(self, env, device=device)
@@ -186,9 +190,13 @@ class Envelope(MOPolicy, MOAgent):
                 action_dtype=np.uint8,
             )
 
+        self.seed = seed
+        if self.seed is not None:
+            th.manual_seed(self.seed)
+            np.random.seed(self.seed)
         self.log = log
         if log:
-            self.setup_wandb(project_name, experiment_name)
+            self.setup_wandb(project_name, experiment_name, wandb_entity)
 
     @override
     def get_config(self):
@@ -212,6 +220,7 @@ class Envelope(MOPolicy, MOAgent):
             "final_homotopy_lambda": self.final_homotopy_lambda,
             "homotopy_decay_steps": self.homotopy_decay_steps,
             "learning_starts": self.learning_starts,
+            "seed": self.seed,
         }
 
     def save(self, save_replay_buffer: bool = True, save_dir: str = "weights/", filename: Optional[str] = None):

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -120,7 +120,9 @@ class GPIPD(MOPolicy, MOAgent):
         real_ratio: float = 0.05,
         project_name: str = "MORL-Baselines",
         experiment_name: str = "GPI-PD",
+        wandb_entity: Optional[str] = None,
         log: bool = True,
+        seed: Optional[int] = None,
         device: Union[th.device, str] = "auto",
     ):
         """Initialize the GPI-PD algorithm.
@@ -163,7 +165,9 @@ class GPIPD(MOPolicy, MOAgent):
             real_ratio: The ratio of real transitions to sample.
             project_name: The name of the project.
             experiment_name: The name of the experiment.
+            wandb_entity: The name of the wandb entity.
             log: Whether to log.
+            seed: The seed for random number generators.
             device: The device to use.
         """
         MOAgent.__init__(self, env, device=device)
@@ -254,9 +258,14 @@ class GPIPD(MOPolicy, MOAgent):
         self.dynamics_uncertainty_threshold = dynamics_uncertainty_threshold
         self.real_ratio = real_ratio
 
+        self.seed = seed
+        if self.seed is not None:
+            th.random.manual_seed(self.seed)
+            np.random.seed(self.seed)
+        # logging
         self.log = log
         if self.log:
-            self.setup_wandb(project_name, experiment_name)
+            self.setup_wandb(project_name, experiment_name, wandb_entity)
 
     def get_config(self):
         """Return the configuration of the agent."""
@@ -293,6 +302,7 @@ class GPIPD(MOPolicy, MOAgent):
             "real_ratio": self.real_ratio,
             "drop_rate": self.drop_rate,
             "layer_norm": self.layer_norm,
+            "seed": self.seed,
         }
 
     def save(self, save_replay_buffer=True, save_dir="weights/", filename=None):

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -763,7 +763,8 @@ class GPIPD(MOPolicy, MOAgent):
             timesteps_per_iter (int): Number of timesteps to train for per iteration
             weight_selection_algo (str): Weight selection algorithm to use
         """
-        self.register_additional_config(ref_point, known_pareto_front)
+        if self.log:
+            self.register_additional_config(ref_point, known_pareto_front)
         max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -30,6 +30,7 @@ from morl_baselines.common.utils import (
     log_all_multi_policy_metrics,
     log_episode_info,
     polyak_update,
+    seed_everything,
 )
 from morl_baselines.multi_policy.linear_support.linear_support import LinearSupport
 
@@ -260,8 +261,7 @@ class GPIPD(MOPolicy, MOAgent):
 
         self.seed = seed
         if self.seed is not None:
-            th.random.manual_seed(self.seed)
-            np.random.seed(self.seed)
+            seed_everything(self.seed)
         # logging
         self.log = log
         if self.log:

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -742,25 +742,26 @@ class GPIPD(MOPolicy, MOAgent):
 
     def train(
         self,
+        total_timesteps: int,
         eval_env,
         ref_point: np.ndarray,
         known_pareto_front: Optional[List[np.ndarray]] = None,
         eval_weights_number_for_front: int = 100,
         timesteps_per_iter: int = 10000,
-        max_iter: int = 15,
         weight_selection_algo: str = "gpi-ls",
     ):
         """Train agent.
 
         Args:
+            total_timesteps (int): Number of timesteps to train for
             eval_env (gym.Env): Environment to evaluate on
             ref_point (np.ndarray): Reference point for hypervolume calculation
             known_pareto_front (Optional[List[np.ndarray]]): Optimal Pareto front if known.
             eval_weights_number_for_front: Number of weights to evaluate for the Pareto front
             timesteps_per_iter (int): Number of timesteps to train for per iteration
-            max_iter (int): Number of iterations to train for
             weight_selection_algo (str): Weight selection algorithm to use
         """
+        max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 
         weight_history = []

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -31,6 +31,7 @@ from morl_baselines.common.utils import (
     log_episode_info,
     polyak_update,
     seed_everything,
+    unique_tol,
 )
 from morl_baselines.multi_policy.linear_support.linear_support import LinearSupport
 
@@ -650,7 +651,8 @@ class GPIPD(MOPolicy, MOAgent):
 
     def set_weight_support(self, weight_list: List[np.ndarray]):
         """Set the weight support set."""
-        self.weight_support = [th.tensor(w).float().to(self.device) for w in weight_list]
+        weights_no_repeats = unique_tol(weight_list)
+        self.weight_support = [th.tensor(w).float().to(self.device) for w in weights_no_repeats]
 
     def train_iteration(
         self,
@@ -675,7 +677,7 @@ class GPIPD(MOPolicy, MOAgent):
             eval_freq (int): Number of timesteps between evaluations
             reset_learning_starts (bool): Whether to reset the learning starts
         """
-        self.weight_support = [th.tensor(z).float().to(self.device) for z in weight_support]
+        self.set_weight_support(weight_support)
         tensor_w = th.tensor(weight).float().to(self.device)
 
         self.police_indices = []

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -761,6 +761,7 @@ class GPIPD(MOPolicy, MOAgent):
             timesteps_per_iter (int): Number of timesteps to train for per iteration
             weight_selection_algo (str): Weight selection algorithm to use
         """
+        self.register_additional_config(ref_point, known_pareto_front)
         max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -766,7 +766,7 @@ class GPIPD(MOPolicy, MOAgent):
             weight_selection_algo (str): Weight selection algorithm to use
         """
         if self.log:
-            self.register_additional_config(ref_point, known_pareto_front)
+            self.register_additional_config({"ref_point": ref_point.tolist(), "known_front": known_pareto_front})
         max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -596,7 +596,8 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
             timesteps_per_iter (int): Number of timesteps to train the agent for each iteration.
             eval_freq (int): Number of timesteps between evaluations during an iteration.
         """
-        self.register_additional_config(ref_point, known_pareto_front)
+        if self.log:
+            self.register_additional_config(ref_point, known_pareto_front)
         max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -601,7 +601,7 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
             eval_freq (int): Number of timesteps between evaluations during an iteration.
         """
         if self.log:
-            self.register_additional_config(ref_point, known_pareto_front)
+            self.register_additional_config({"ref_point": ref_point.tolist(), "known_front": known_pareto_front})
         max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -27,6 +27,7 @@ from morl_baselines.common.utils import (
     log_all_multi_policy_metrics,
     log_episode_info,
     polyak_update,
+    seed_everything,
 )
 from morl_baselines.multi_policy.linear_support.linear_support import LinearSupport
 
@@ -239,8 +240,7 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
 
         self.seed = seed
         if self.seed is not None:
-            th.manual_seed(self.seed)
-            np.random.seed(self.seed)
+            seed_everything(self.seed)
 
         self.log = log
         if self.log:

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -28,6 +28,7 @@ from morl_baselines.common.utils import (
     log_episode_info,
     polyak_update,
     seed_everything,
+    unique_tol,
 )
 from morl_baselines.multi_policy.linear_support.linear_support import LinearSupport
 
@@ -480,7 +481,8 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
 
     def set_weight_support(self, weight_list: List[np.ndarray]):
         """Set the weight support set."""
-        self.weight_support = [th.tensor(w).float().to(self.device) for w in weight_list]
+        weights_no_repeat = unique_tol(weight_list)
+        self.weight_support = [th.tensor(w).float().to(self.device) for w in weights_no_repeat]
         if len(self.weight_support) > 0:
             self.stacked_weight_support = th.stack(self.weight_support)
 

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -114,7 +114,9 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
         dynamics_real_ratio: float = 0.1,
         project_name: str = "MORL-Baselines",
         experiment_name: str = "GPI-PD Continuous Action",
+        wandb_entity: Optional[str] = None,
         log: bool = True,
+        seed: Optional[int] = None,
         device: Union[th.device, str] = "auto",
     ):
         """GPI-PD algorithm with continuous actions.
@@ -152,7 +154,9 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
             dynamics_real_ratio (float, optional): The ratio of real data to use for the dynamics model. Defaults to 0.1.
             project_name (str, optional): The name of the project. Defaults to "MORL Baselines".
             experiment_name (str, optional): The name of the experiment. Defaults to "GPI-PD Continuous Action".
+            wandb_entity (Optional[str], optional): The wandb entity. Defaults to None.
             log (bool, optional): Whether to log to wandb. Defaults to True.
+            seed (Optional[int], optional): The seed to use. Defaults to None.
             device (Union[th.device, str], optional): The device to use for training. Defaults to "auto".
         """
         MOAgent.__init__(self, env, device=device)
@@ -233,9 +237,14 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
 
         self._n_updates = 0
 
+        self.seed = seed
+        if self.seed is not None:
+            th.manual_seed(self.seed)
+            np.random.seed(self.seed)
+
         self.log = log
         if self.log:
-            self.setup_wandb(project_name, experiment_name)
+            self.setup_wandb(project_name, experiment_name, wandb_entity)
 
     def get_config(self):
         """Get the configuration of the agent."""
@@ -260,6 +269,11 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
             "dynamics_rollout_len": self.dynamics_rollout_len,
             "dynamics_min_uncertainty": self.dynamics_min_uncertainty,
             "dynamics_real_ratio": self.dynamics_real_ratio,
+            "dynamics_train_freq": self.dynamics_train_freq,
+            "dynamics_rollout_starts": self.dynamics_rollout_starts,
+            "dynamics_rollout_freq": self.dynamics_rollout_freq,
+            "dynamics_rollout_batch_size": self.dynamics_rollout_batch_size,
+            "seed": self.seed,
         }
 
     def save(self, save_dir="weights/", filename=None, save_replay_buffer=True):

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -573,27 +573,28 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
 
     def train(
         self,
+        total_timesteps: int,
         eval_env: gymnasium.Env,
         ref_point: np.ndarray,
         known_pareto_front: Optional[List[np.ndarray]] = None,
         eval_weights_number_for_front: int = 100,
         weight_selection_algo: str = "gpi-ls",
         timesteps_per_iter: int = 10000,
-        max_iter: int = 10,
         eval_freq: int = 1000,
     ):
         """Train the agent.
 
         Args:
+            total_timesteps (int): Total number of timesteps to train the agent for.
             eval_env (gym.Env): Environment to use for evaluation.
             ref_point (np.ndarray): Reference point for hypervolume calculation
             known_pareto_front (Optional[List[np.ndarray]]): Optimal Pareto front, if known.
             eval_weights_number_for_front (int): Number of weights to evaluate for the Pareto front
             weight_selection_algo (str): Weight selection algorithm to use.
             timesteps_per_iter (int): Number of timesteps to train the agent for each iteration.
-            max_iter (int): Maximum number of iterations to train the agent for.
             eval_freq (int): Number of timesteps between evaluations during an iteration.
         """
+        max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 
         eval_weights = equally_spaced_weights(self.reward_dim, n=eval_weights_number_for_front)

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -594,6 +594,7 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
             timesteps_per_iter (int): Number of timesteps to train the agent for each iteration.
             eval_freq (int): Number of timesteps between evaluations during an iteration.
         """
+        self.register_additional_config(ref_point, known_pareto_front)
         max_iter = total_timesteps // timesteps_per_iter
         linear_support = LinearSupport(num_objectives=self.reward_dim, epsilon=0.0 if weight_selection_algo == "ols" else None)
 

--- a/morl_baselines/multi_policy/linear_support/linear_support.py
+++ b/morl_baselines/multi_policy/linear_support/linear_support.py
@@ -237,28 +237,26 @@ class LinearSupport:
         return W_del
 
     def remove_obsolete_values(self, value: np.ndarray) -> List[int]:
-        """Removes the values vectors which are dominated by the new value for all visited weight vectors.
+        """Removes the values vectors which are no longer optimal for any weight vector after adding the new value vector.
 
         Args:
-            value: New value vector
+            value (np.ndarray): New value vector
 
         Returns:
-             the indices of the removed values.
+            The indices of the removed values.
         """
         removed_indx = []
         for i in reversed(range(len(self.ccs))):
-            best_in_all = True
-            for j in range(len(self.visited_weights)):
-                w = self.visited_weights[j]
-                if np.dot(value, w) < np.dot(self.ccs[i], w):
-                    best_in_all = False
-                    break
-
-            if best_in_all:
+            weights_optimal = [
+                w
+                for w in self.visited_weights
+                if np.dot(self.ccs[i], w) == self.max_scalarized_value(w) and np.dot(value, w) < np.dot(self.ccs[i], w)
+            ]
+            if len(weights_optimal) == 0:
+                print("removed value", self.ccs[i])
                 removed_indx.append(i)
                 self.ccs.pop(i)
                 self.weight_support.pop(i)
-
         return removed_indx
 
     def max_value_lp(self, w_new: np.ndarray) -> float:

--- a/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
+++ b/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
@@ -180,7 +180,7 @@ class MPMOQLearning(MOAgent):
             num_episodes_eval: The number of episodes used to evaluate the value of a policy.
         """
         if self.log:
-            self.register_additional_config(ref_point, known_pareto_front)
+            self.register_additional_config({"ref_point": ref_point.tolist(), "known_front": known_pareto_front})
         num_iterations = int(total_timesteps / timesteps_per_iteration)
         if eval_env is None:
             eval_env = deepcopy(self.env)

--- a/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
+++ b/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
@@ -179,6 +179,7 @@ class MPMOQLearning(MOAgent):
             epsilon_linear_support: The epsilon value for the linear support algorithm.
             num_episodes_eval: The number of episodes used to evaluate the value of a policy.
         """
+        self.register_additional_config(ref_point, known_pareto_front)
         num_iterations = int(total_timesteps / timesteps_per_iteration)
         if eval_env is None:
             eval_env = deepcopy(self.env)

--- a/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
+++ b/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
@@ -179,7 +179,8 @@ class MPMOQLearning(MOAgent):
             epsilon_linear_support: The epsilon value for the linear support algorithm.
             num_episodes_eval: The number of episodes used to evaluate the value of a policy.
         """
-        self.register_additional_config(ref_point, known_pareto_front)
+        if self.log:
+            self.register_additional_config(ref_point, known_pareto_front)
         num_iterations = int(total_timesteps / timesteps_per_iteration)
         if eval_env is None:
             eval_env = deepcopy(self.env)

--- a/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
+++ b/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
@@ -42,6 +42,8 @@ class MPMOQLearning(MOAgent):
         dyna_updates: int = 5,
         project_name: str = "MORL-Baselines",
         experiment_name: str = "MultiPolicy MO Q-Learning",
+        wandb_entity: Optional[str] = None,
+        seed: Optional[int] = None,
         log: bool = True,
     ):
         """Initialize the Multi-policy MOQ-learning algorithm.
@@ -62,6 +64,8 @@ class MPMOQLearning(MOAgent):
             dyna_updates: The number of Dyna-Q updates to perform.
             project_name: The name of the project for logging.
             experiment_name: The name of the experiment for logging.
+            wandb_entity: The entity to use for logging.
+            seed: The seed to use for reproducibility.
             log: Whether to log or not.
         """
         MOAgent.__init__(self, env)
@@ -92,8 +96,13 @@ class MPMOQLearning(MOAgent):
         self.experiment_name = experiment_name
         self.log = log
 
+        # Seed
+        self.seed = seed
+        if self.seed is not None:
+            np.random.seed(self.seed)
+
         if self.log:
-            self.setup_wandb(project_name=self.project_name, experiment_name=self.experiment_name)
+            self.setup_wandb(project_name=self.project_name, experiment_name=self.experiment_name, entity=wandb_entity)
         else:
             self.writer = None
 
@@ -113,6 +122,7 @@ class MPMOQLearning(MOAgent):
             "transfer_q_table": self.transfer_q_table,
             "dyna": self.dyna,
             "dyna_updates": self.dyna_updates,
+            "seed": self.seed,
         }
 
     def _gpi_action(self, state: np.ndarray, w: np.ndarray) -> int:
@@ -198,6 +208,7 @@ class MPMOQLearning(MOAgent):
                 dyna_updates=self.dyna_updates,
                 log=self.log,
                 parent_writer=self.writer,
+                seed=self.seed,
             )
             if self.transfer_q_table and len(self.policies) > 0:
                 reuse_ind = np.argmax([np.dot(w, v) for v in self.linear_support.ccs])

--- a/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
+++ b/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
@@ -14,6 +14,7 @@ from morl_baselines.common.utils import (
     equally_spaced_weights,
     log_all_multi_policy_metrics,
     random_weights,
+    seed_everything,
 )
 from morl_baselines.multi_policy.linear_support.linear_support import LinearSupport
 from morl_baselines.single_policy.ser.mo_q_learning import MOQLearning
@@ -99,7 +100,7 @@ class MPMOQLearning(MOAgent):
         # Seed
         self.seed = seed
         if self.seed is not None:
-            np.random.seed(self.seed)
+            seed_everything(self.seed)
 
         if self.log:
             self.setup_wandb(project_name=self.project_name, experiment_name=self.experiment_name, entity=wandb_entity)

--- a/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
+++ b/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
@@ -160,8 +160,8 @@ class MPMOQLearning(MOAgent):
         total_timesteps: int,
         eval_env: gym.Env,
         ref_point: np.ndarray,
-        timesteps_per_iteration: int = int(2e5),
         known_pareto_front: Optional[List[np.ndarray]] = None,
+        timesteps_per_iteration: int = int(2e5),
         eval_weights_number_for_front: int = 100,
         eval_freq: int = 1000,
         num_episodes_eval: int = 10,
@@ -172,9 +172,9 @@ class MPMOQLearning(MOAgent):
             total_timesteps: The total number of timesteps to train for.
             eval_env: The environment to use for evaluation.
             ref_point: The reference point for the hypervolume calculation.
+            known_pareto_front: The optimal Pareto front, if known. Used for metrics.
             timesteps_per_iteration: The number of timesteps per iteration.
             eval_freq: The frequency of evaluation.
-            known_pareto_front: The optimal Pareto front, if known. Used for metrics.
             eval_weights_number_for_front: The number of weights to use to construct a Pareto front for evaluation.
             epsilon_linear_support: The epsilon value for the linear support algorithm.
             num_episodes_eval: The number of episodes used to evaluate the value of a policy.

--- a/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
+++ b/morl_baselines/multi_policy/multi_policy_moqlearning/mp_mo_q_learning.py
@@ -156,10 +156,10 @@ class MPMOQLearning(MOAgent):
 
     def train(
         self,
+        total_timesteps: int,
         eval_env: gym.Env,
         ref_point: np.ndarray,
-        num_iterations: int,
-        timesteps_per_iteration: int,
+        timesteps_per_iteration: int = int(2e5),
         known_pareto_front: Optional[List[np.ndarray]] = None,
         eval_weights_number_for_front: int = 100,
         eval_freq: int = 1000,
@@ -168,9 +168,9 @@ class MPMOQLearning(MOAgent):
         """Learn a set of policies.
 
         Args:
+            total_timesteps: The total number of timesteps to train for.
             eval_env: The environment to use for evaluation.
             ref_point: The reference point for the hypervolume calculation.
-            num_iterations: The number of iterations/policies to train.
             timesteps_per_iteration: The number of timesteps per iteration.
             eval_freq: The frequency of evaluation.
             known_pareto_front: The optimal Pareto front, if known. Used for metrics.
@@ -178,6 +178,7 @@ class MPMOQLearning(MOAgent):
             epsilon_linear_support: The epsilon value for the linear support algorithm.
             num_episodes_eval: The number of episodes used to evaluate the value of a policy.
         """
+        num_iterations = int(total_timesteps / timesteps_per_iteration)
         if eval_env is None:
             eval_env = deepcopy(self.env)
 

--- a/morl_baselines/multi_policy/pareto_q_learning/pql.py
+++ b/morl_baselines/multi_policy/pareto_q_learning/pql.py
@@ -202,7 +202,7 @@ class PQL(MOAgent):
         if eval_ref_point is None:
             eval_ref_point = self.ref_point
         if self.log:
-            self.register_additional_config(eval_ref_point, known_pareto_front)
+            self.register_additional_config({"ref_point": eval_ref_point.tolist(), "known_front": known_pareto_front})
 
         while self.global_step < total_timesteps:
             state, _ = self.env.reset()

--- a/morl_baselines/multi_policy/pareto_q_learning/pql.py
+++ b/morl_baselines/multi_policy/pareto_q_learning/pql.py
@@ -201,6 +201,7 @@ class PQL(MOAgent):
             raise Exception("No other method implemented yet")
         if eval_ref_point is None:
             eval_ref_point = self.ref_point
+        self.register_additional_config(eval_ref_point, known_pareto_front)
 
         while self.global_step < total_timesteps:
             state, _ = self.env.reset()

--- a/morl_baselines/multi_policy/pareto_q_learning/pql.py
+++ b/morl_baselines/multi_policy/pareto_q_learning/pql.py
@@ -201,7 +201,8 @@ class PQL(MOAgent):
             raise Exception("No other method implemented yet")
         if eval_ref_point is None:
             eval_ref_point = self.ref_point
-        self.register_additional_config(eval_ref_point, known_pareto_front)
+        if self.log:
+            self.register_additional_config(eval_ref_point, known_pareto_front)
 
         while self.global_step < total_timesteps:
             state, _ = self.env.reset()

--- a/morl_baselines/multi_policy/pareto_q_learning/pql.py
+++ b/morl_baselines/multi_policy/pareto_q_learning/pql.py
@@ -24,9 +24,10 @@ class PQL(MOAgent):
         initial_epsilon: float = 1.0,
         epsilon_decay: float = 0.99,
         final_epsilon: float = 0.1,
-        seed: int = None,
+        seed: Optional[int] = None,
         project_name: str = "MORL-Baselines",
         experiment_name: str = "Pareto Q-Learning",
+        wandb_entity: Optional[str] = None,
         log: bool = True,
     ):
         """Initialize the Pareto Q-learning algorithm.
@@ -41,6 +42,7 @@ class PQL(MOAgent):
             seed: The random seed.
             project_name: The name of the project used for logging.
             experiment_name: The name of the experiment used for logging.
+            wandb_entity: The wandb entity used for logging.
             log: Whether to log or not.
         """
         super().__init__(env)
@@ -74,7 +76,7 @@ class PQL(MOAgent):
         self.log = log
 
         if self.log:
-            self.setup_wandb(project_name=self.project_name, experiment_name=self.experiment_name)
+            self.setup_wandb(project_name=self.project_name, experiment_name=self.experiment_name, entity=wandb_entity)
 
     def get_config(self) -> dict:
         """Get the configuration dictionary.

--- a/morl_baselines/multi_policy/pareto_q_learning/pql.py
+++ b/morl_baselines/multi_policy/pareto_q_learning/pql.py
@@ -6,7 +6,7 @@ import numpy as np
 from morl_baselines.common.morl_algorithm import MOAgent
 from morl_baselines.common.pareto import get_non_dominated
 from morl_baselines.common.performance_indicators import hypervolume
-from morl_baselines.common.utils import log_all_multi_policy_metrics
+from morl_baselines.common.utils import log_all_multi_policy_metrics, seed_everything
 
 
 class PQL(MOAgent):
@@ -55,7 +55,9 @@ class PQL(MOAgent):
 
         # Algorithm setup
         self.seed = seed
-        self.rng = np.random.default_rng(seed)
+        if self.seed is not None:
+            seed_everything(self.seed)
+            self.rng = np.random.default_rng(seed)
         self.ref_point = ref_point
 
         self.num_actions = self.env.action_space.n

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -329,6 +329,7 @@ class PCN(MOAgent, MOPolicy):
     def train(
         self,
         total_timesteps: int,
+        eval_env: gym.Env,
         ref_point: np.ndarray,
         known_pareto_front: Optional[List[np.ndarray]] = None,
         num_er_episodes: int = 500,
@@ -341,6 +342,7 @@ class PCN(MOAgent, MOPolicy):
 
         Args:
             total_timesteps: total number of time steps to train for
+            eval_env: environment for evaluation
             ref_point: reference point for hypervolume calculation
             known_pareto_front: Optimal pareto front for metrics calculation, if known.
             num_er_episodes: number of episodes to fill experience replay buffer
@@ -349,6 +351,7 @@ class PCN(MOAgent, MOPolicy):
             max_return: maximum return for clipping desired return
             max_buffer_size: maximum buffer size
         """
+        self.register_additional_config(ref_point, known_pareto_front)
         self.global_step = 0
         total_episodes = num_er_episodes
         n_checkpoints = 0
@@ -425,7 +428,7 @@ class PCN(MOAgent, MOPolicy):
                 self.save()
                 n_checkpoints += 1
                 n_points = 10
-                e_returns, _, _ = self.evaluate(self.env, max_return, n=n_points)
+                e_returns, _, _ = self.evaluate(eval_env, max_return, n=n_points)
 
                 if self.log:
                     log_all_multi_policy_metrics(

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 from morl_baselines.common.morl_algorithm import MOAgent, MOPolicy
 from morl_baselines.common.pareto import get_non_dominated_inds
 from morl_baselines.common.performance_indicators import hypervolume
-from morl_baselines.common.utils import log_all_multi_policy_metrics
+from morl_baselines.common.utils import log_all_multi_policy_metrics, seed_everything
 
 
 def crowding_distance(points):
@@ -142,8 +142,7 @@ class PCN(MOAgent, MOPolicy):
 
         self.seed = seed
         if self.seed is not None:
-            th.manual_seed(self.seed)
-            np.random.seed(self.seed)
+            seed_everything(self.seed)
 
         self.log = log
         if log:

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -351,7 +351,8 @@ class PCN(MOAgent, MOPolicy):
             max_return: maximum return for clipping desired return
             max_buffer_size: maximum buffer size
         """
-        self.register_additional_config(ref_point, known_pareto_front)
+        if self.log:
+            self.register_additional_config(ref_point, known_pareto_front)
         self.global_step = 0
         total_episodes = num_er_episodes
         n_checkpoints = 0

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -102,7 +102,9 @@ class PCN(MOAgent, MOPolicy):
         hidden_dim: int = 64,
         project_name: str = "MORL-Baselines",
         experiment_name: str = "PCN",
-        log: bool = False,
+        wandb_entity: Optional[str] = None,
+        log: bool = True,
+        seed: Optional[int] = None,
         device: Union[th.device, str] = "auto",
     ) -> None:
         """Initialize PCN agent.
@@ -116,7 +118,9 @@ class PCN(MOAgent, MOPolicy):
             hidden_dim (int, optional): Hidden dimension. Defaults to 64.
             project_name (str, optional): Name of the project for wandb. Defaults to "MORL-Baselines".
             experiment_name (str, optional): Name of the experiment for wandb. Defaults to "PCN".
-            log (bool, optional): Whether to log to wandb. Defaults to False.
+            wandb_entity (Optional[str], optional): Entity for wandb. Defaults to None.
+            log (bool, optional): Whether to log to wandb. Defaults to True.
+            seed (Optional[int], optional): Seed for reproducibility. Defaults to None.
             device (Union[th.device, str], optional): Device to use. Defaults to "auto".
         """
         MOAgent.__init__(self, env, device=device)
@@ -136,9 +140,14 @@ class PCN(MOAgent, MOPolicy):
         ).to(self.device)
         self.opt = th.optim.Adam(self.model.parameters(), lr=self.learning_rate)
 
+        self.seed = seed
+        if self.seed is not None:
+            th.manual_seed(self.seed)
+            np.random.seed(self.seed)
+
         self.log = log
         if log:
-            self.setup_wandb(project_name, experiment_name)
+            self.setup_wandb(project_name, experiment_name, wandb_entity)
 
     def get_config(self) -> dict:
         """Get configuration of PCN model."""
@@ -149,6 +158,7 @@ class PCN(MOAgent, MOPolicy):
             "learning_rate": self.learning_rate,
             "hidden_dim": self.hidden_dim,
             "scaling_factor": self.scaling_factor,
+            "seed": self.seed,
         }
 
     def update(self):

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -352,7 +352,7 @@ class PCN(MOAgent, MOPolicy):
             max_buffer_size: maximum buffer size
         """
         if self.log:
-            self.register_additional_config(ref_point, known_pareto_front)
+            self.register_additional_config({"ref_point": ref_point.tolist(), "known_front": known_pareto_front})
         self.global_step = 0
         total_episodes = num_er_episodes
         n_checkpoints = 0

--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -433,10 +433,11 @@ class PGMORL(MOAgent):
 
         # env setup
         if env is None:
-            self.env = mo_gym.MOSyncVectorEnv(
-                # Video recording is disabled since broken for now
-                [make_env(env_id, self.seed + i, i, experiment_name, self.gamma) for i in range(1, self.num_envs + 1)]
-            )
+            if self.seed is not None:
+                envs = [make_env(env_id, self.seed + i, i, experiment_name, self.gamma) for i in range(self.num_envs)]
+            else:
+                envs = [make_env(env_id, i, i, experiment_name, self.gamma) for i in range(self.num_envs)]
+            self.env = mo_gym.MOSyncVectorEnv(envs)
         else:
             raise ValueError("Environments should be vectorized for PPO. You should provide an environment id instead.")
 

--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -619,6 +619,7 @@ class PGMORL(MOAgent):
         known_pareto_front: Optional[List[np.ndarray]] = None,
     ):
         """Trains the agents."""
+        self.register_additional_config(ref_point, known_pareto_front)
         max_iterations = total_timesteps // self.steps_per_iteration // self.num_envs
         iteration = 0
         # Init

--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -291,13 +291,10 @@ class PGMORL(MOAgent):
     def __init__(
         self,
         env_id: str,
-        ref_point: np.ndarray,
-        known_pareto_front: Optional[List[np.ndarray]] = None,
         num_envs: int = 4,
         pop_size: int = 6,
         warmup_iterations: int = 80,
         steps_per_iteration: int = 2048,
-        limit_env_steps: int = int(5e6),
         evolutionary_iterations: int = 20,
         num_weight_candidates: int = 7,
         num_performance_buffer: int = 100,
@@ -333,13 +330,10 @@ class PGMORL(MOAgent):
 
         Args:
             env_id: environment id
-            ref_point: reference point for the hypervolume calculation
-            known_pareto_front: known pareto front, if available
             num_envs: number of environments to use (VectorizedEnvs)
             pop_size: population size
             warmup_iterations: number of warmup iterations
             steps_per_iteration: number of steps per iteration
-            limit_env_steps: limit the number of environment steps
             evolutionary_iterations: number of evolutionary iterations
             num_weight_candidates: number of weight candidates
             num_performance_buffer: number of performance buffers
@@ -380,8 +374,6 @@ class PGMORL(MOAgent):
         assert isinstance(self.action_space, gym.spaces.Box), "only continuous action space is supported"
         self.tmp_env.close()
         self.gamma = gamma
-        self.ref_point = ref_point
-        self.known_pareto_front = known_pareto_front
 
         # EA parameters
         self.pop_size = pop_size
@@ -392,9 +384,6 @@ class PGMORL(MOAgent):
         self.min_weight = min_weight
         self.max_weight = max_weight
         self.delta_weight = delta_weight
-        self.limit_env_steps = limit_env_steps
-        self.max_iterations = self.limit_env_steps // self.steps_per_iteration // self.num_envs
-        self.iteration = 0
         self.num_performance_buffer = num_performance_buffer
         self.performance_buffer_size = performance_buffer_size
         self.archive = ParetoArchive()
@@ -493,14 +482,10 @@ class PGMORL(MOAgent):
     def get_config(self) -> dict:
         return {
             "env_id": self.env_id,
-            "ref_point": self.ref_point,
             "num_envs": self.num_envs,
             "pop_size": self.pop_size,
             "warmup_iterations": self.warmup_iterations,
             "evolutionary_iterations": self.evolutionary_iterations,
-            "steps_per_iteration": self.steps_per_iteration,
-            "limit_env_steps": self.limit_env_steps,
-            "max_iterations": self.max_iterations,
             "num_weight_candidates": self.num_weight_candidates,
             "num_performance_buffer": self.num_performance_buffer,
             "performance_buffer_size": self.performance_buffer_size,
@@ -526,11 +511,17 @@ class PGMORL(MOAgent):
             "gae_lambda": self.gae_lambda,
         }
 
-    def __train_all_agents(self):
+    def __train_all_agents(self, iteration: int, max_iterations: int):
         for i, agent in enumerate(self.agents):
-            agent.train(self.start_time, self.iteration, self.max_iterations)
+            agent.train(self.start_time, iteration, max_iterations)
 
-    def __eval_all_agents(self, evaluations_before_train: List[np.ndarray], add_to_prediction: bool = True):
+    def __eval_all_agents(
+        self,
+        evaluations_before_train: List[np.ndarray],
+        ref_point: np.ndarray,
+        known_pareto_front: Optional[List[np.ndarray]] = None,
+        add_to_prediction: bool = True,
+    ):
         """Evaluates all agents and store their current performances on the buffer and pareto archive."""
         for i, agent in enumerate(self.agents):
             _, _, _, discounted_reward = agent.policy_eval(self.env.envs[0], weights=agent.weights, writer=self.writer)
@@ -550,14 +541,14 @@ class PGMORL(MOAgent):
             print(self.archive.evaluations)
             log_all_multi_policy_metrics(
                 current_front=self.archive.evaluations,
-                hv_ref_point=self.ref_point,
+                hv_ref_point=ref_point,
                 reward_dim=self.reward_dim,
                 global_step=self.global_step,
                 writer=self.writer,
-                ref_front=self.known_pareto_front,
+                ref_front=known_pareto_front,
             )
 
-    def __task_weight_selection(self):
+    def __task_weight_selection(self, ref_point: np.ndarray):
         """Chooses agents and weights to train at the next iteration based on the current population and prediction model."""
         candidate_weights = generate_weights(self.delta_weight / 2.0)  # Generates more weights than agents
         np.random.shuffle(candidate_weights)  # Randomize
@@ -627,28 +618,37 @@ class PGMORL(MOAgent):
                 f"current eval: {best_eval} - estimated next: {best_predicted_eval} - deltas {(best_predicted_eval - best_eval)}"
             )
 
-    def train(self):
+    def train(
+        self,
+        total_timesteps: int,
+        ref_point: np.ndarray,
+        known_pareto_front: Optional[List[np.ndarray]] = None,
+    ):
         """Trains the agents."""
+        max_iterations = total_timesteps // self.steps_per_iteration // self.num_envs
+        iteration = 0
         # Init
         current_evaluations = [np.zeros(self.reward_dim) for _ in range(len(self.agents))]
-        self.__eval_all_agents(current_evaluations, add_to_prediction=False)
+        self.__eval_all_agents(
+            current_evaluations, ref_point=ref_point, known_pareto_front=known_pareto_front, add_to_prediction=False
+        )
         self.start_time = time.time()
 
         # Warmup
         for i in range(1, self.warmup_iterations + 1):
-            print(f"Warmup iteration #{self.iteration}")
+            print(f"Warmup iteration #{iteration}")
             if self.log:
                 self.writer.add_scalar("charts/warmup_iterations", i)
-            self.__train_all_agents()
-            self.iteration += 1
-        self.__eval_all_agents(current_evaluations)
+            self.__train_all_agents(iteration=iteration, max_iterations=max_iterations)
+            iteration += 1
+        self.__eval_all_agents(current_evaluations, ref_point=ref_point, known_pareto_front=known_pareto_front)
 
         # Evolution
-        max_iterations = max(self.max_iterations, self.warmup_iterations + self.evolutionary_iterations)
+        max_iterations = max(max_iterations, self.warmup_iterations + self.evolutionary_iterations)
         evolutionary_generation = 1
-        while self.iteration < max_iterations:
+        while iteration < max_iterations:
             # Every evolutionary iterations, change the task - weight assignments
-            self.__task_weight_selection()
+            self.__task_weight_selection(ref_point=ref_point)
             print(f"Evolutionary generation #{evolutionary_generation}")
             if self.log:
                 self.writer.add_scalar("charts/evolutionary_generation", evolutionary_generation)
@@ -656,14 +656,14 @@ class PGMORL(MOAgent):
             for _ in range(self.evolutionary_iterations):
                 # Run training of every agent for evolutionary iterations.
                 if self.log:
-                    print(f"Evolutionary iteration #{self.iteration - self.warmup_iterations}")
+                    print(f"Evolutionary iteration #{iteration - self.warmup_iterations}")
                     self.writer.add_scalar(
                         "charts/evolutionary_iterations",
-                        self.iteration - self.warmup_iterations,
+                        iteration - self.warmup_iterations,
                     )
-                self.__train_all_agents()
-                self.iteration += 1
-            self.__eval_all_agents(current_evaluations)
+                self.__train_all_agents(iteration=iteration, max_iterations=max_iterations)
+                iteration += 1
+            self.__eval_all_agents(current_evaluations, ref_point=ref_point, known_pareto_front=known_pareto_front)
             evolutionary_generation += 1
 
         print("Done training!")

--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -309,7 +309,8 @@ class PGMORL(MOAgent):
         gamma: float = 0.995,
         project_name: str = "MORL-baselines",
         experiment_name: str = "PGMORL",
-        seed: int = 0,
+        wandb_entity: Optional[str] = None,
+        seed: Optional[int] = None,
         torch_deterministic: bool = True,
         log: bool = True,
         net_arch: List = [64, 64],
@@ -350,6 +351,7 @@ class PGMORL(MOAgent):
             gamma: discount factor
             project_name: name of the project. Usually MORL-baselines.
             experiment_name: name of the experiment. Usually PGMORL.
+            wandb_entity: wandb entity, defaults to None.
             seed: seed for the random number generator
             torch_deterministic: whether to use deterministic torch operations
             log: whether to log the results
@@ -423,9 +425,10 @@ class PGMORL(MOAgent):
 
         # seeding
         self.seed = seed
-        random.seed(self.seed)
-        np.random.seed(self.seed)
-        th.manual_seed(self.seed)
+        if self.seed is not None:
+            random.seed(self.seed)
+            np.random.seed(self.seed)
+            th.manual_seed(self.seed)
         th.backends.cudnn.deterministic = torch_deterministic
 
         # env setup
@@ -440,7 +443,7 @@ class PGMORL(MOAgent):
         # Logging
         self.log = log
         if self.log:
-            self.setup_wandb(project_name, experiment_name)
+            self.setup_wandb(project_name, experiment_name, wandb_entity)
         else:
             self.writer = None
 

--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -622,7 +622,7 @@ class PGMORL(MOAgent):
     ):
         """Trains the agents."""
         if self.log:
-            self.register_additional_config(ref_point, known_pareto_front)
+            self.register_additional_config({"ref_point": ref_point.tolist(), "known_front": known_pareto_front})
         max_iterations = total_timesteps // self.steps_per_iteration // self.num_envs
         iteration = 0
         # Init

--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -290,6 +290,7 @@ class PGMORL(MOAgent):
     def __init__(
         self,
         env_id: str,
+        origin: np.ndarray,
         num_envs: int = 4,
         pop_size: int = 6,
         warmup_iterations: int = 80,
@@ -328,6 +329,7 @@ class PGMORL(MOAgent):
 
         Args:
             env_id: environment id
+            origin: reference point to make the objectives positive in the performance buffer
             num_envs: number of environments to use (VectorizedEnvs)
             pop_size: population size
             warmup_iterations: number of warmup iterations
@@ -387,7 +389,7 @@ class PGMORL(MOAgent):
         self.population = PerformanceBuffer(
             num_bins=self.num_performance_buffer,
             max_size=self.performance_buffer_size,
-            origin=self.ref_point,
+            origin=origin,
         )
         self.predictor = PerformancePredictor()
 
@@ -619,7 +621,8 @@ class PGMORL(MOAgent):
         known_pareto_front: Optional[List[np.ndarray]] = None,
     ):
         """Trains the agents."""
-        self.register_additional_config(ref_point, known_pareto_front)
+        if self.log:
+            self.register_additional_config(ref_point, known_pareto_front)
         max_iterations = total_timesteps // self.steps_per_iteration // self.num_envs
         iteration = 0
         # Init

--- a/morl_baselines/single_policy/esr/eupg.py
+++ b/morl_baselines/single_policy/esr/eupg.py
@@ -12,7 +12,7 @@ from torch.distributions import Categorical
 from morl_baselines.common.accrued_reward_buffer import AccruedRewardReplayBuffer
 from morl_baselines.common.morl_algorithm import MOAgent, MOPolicy
 from morl_baselines.common.networks import mlp
-from morl_baselines.common.utils import layer_init, log_episode_info
+from morl_baselines.common.utils import layer_init, log_episode_info, seed_everything
 
 
 class PolicyNet(nn.Module):
@@ -118,8 +118,7 @@ class EUPG(MOPolicy, MOAgent):
         self.gamma = gamma
         self.seed = seed
         if self.seed is not None:
-            np.random.seed(self.seed)
-            th.manual_seed(self.seed)
+            seed_everything(self.seed)
 
         # Learning
         self.buffer_size = buffer_size

--- a/morl_baselines/single_policy/esr/eupg.py
+++ b/morl_baselines/single_policy/esr/eupg.py
@@ -88,8 +88,10 @@ class EUPG(MOPolicy, MOAgent):
         learning_rate: float = 1e-3,
         project_name: str = "MORL-Baselines",
         experiment_name: str = "EUPG",
+        wandb_entity: Optional[str] = None,
         log: bool = True,
         device: Union[th.device, str] = "auto",
+        seed: Optional[int] = None,
     ):
         """Initialize the EUPG algorithm.
 
@@ -102,8 +104,10 @@ class EUPG(MOPolicy, MOAgent):
             learning_rate: Learning rate (alpha)
             project_name: Name of the project (for logging)
             experiment_name: Name of the experiment (for logging)
+            wandb_entity: Entity to use for wandb
             log: Whether to log or not
             device: Device to use for NN. Can be "cpu", "cuda" or "auto".
+            seed: Seed for the random number generator
         """
         MOAgent.__init__(self, env, device)
         MOPolicy.__init__(self, None, device)
@@ -112,6 +116,10 @@ class EUPG(MOPolicy, MOAgent):
         # RL
         self.scalarization = scalarization
         self.gamma = gamma
+        self.seed = seed
+        if self.seed is not None:
+            np.random.seed(self.seed)
+            th.manual_seed(self.seed)
 
         # Learning
         self.buffer_size = buffer_size
@@ -138,7 +146,7 @@ class EUPG(MOPolicy, MOAgent):
         self.experiment_name = experiment_name
         self.log = log
         if log:
-            self.setup_wandb(project_name, experiment_name)
+            self.setup_wandb(project_name, experiment_name, wandb_entity)
 
     @override
     def eval(self, obs: np.ndarray, accrued_reward: Optional[np.ndarray]) -> Union[int, np.ndarray]:
@@ -250,4 +258,5 @@ class EUPG(MOPolicy, MOAgent):
             "buffer_size": self.buffer_size,
             "gamma": self.gamma,
             "net_arch": self.net_arch,
+            "seed": self.seed,
         }

--- a/morl_baselines/single_policy/ser/mo_q_learning.py
+++ b/morl_baselines/single_policy/ser/mo_q_learning.py
@@ -36,7 +36,9 @@ class MOQLearning(MOPolicy, MOAgent):
         dyna_updates: int = 5,
         project_name: str = "MORL-baselines",
         experiment_name: str = "MO Q-Learning",
+        wandb_entity: Optional[str] = None,
         log: bool = True,
+        seed: Optional[int] = None,
         parent_writer: Optional[SummaryWriter] = None,
     ):
         """Initializes the MOQ-learning algorithm.
@@ -56,13 +58,18 @@ class MOQLearning(MOPolicy, MOAgent):
             dyna_updates: The number of Dyna-Q updates to perform each step
             project_name: The name of the project used for logging
             experiment_name: The name of the experiment used for logging
+            wandb_entity: The entity to use for logging
             log: Whether to log or not
+            seed: The seed to use for the experiment
             parent_writer: The writer to use for logging. If None, a new writer is created.
         """
         MOAgent.__init__(self, env)
         MOPolicy.__init__(self, id)
         self.learning_rate = learning_rate
         self.id = id
+        self.seed = seed
+        if self.seed is not None:
+            np.random.seed(self.seed)
         if self.id is not None:
             self.idstr = f"_{self.id}"
         else:
@@ -88,7 +95,7 @@ class MOQLearning(MOPolicy, MOAgent):
         if parent_writer is not None:
             self.writer = parent_writer
         if self.log and parent_writer is None:
-            self.setup_wandb(project_name, experiment_name)
+            self.setup_wandb(project_name, experiment_name, wandb_entity)
 
     def __act(self, obs: np.array):
         # epsilon-greedy
@@ -174,6 +181,7 @@ class MOQLearning(MOPolicy, MOAgent):
             "dyna_updates": self.dyna_updates,
             "weight": self.weights,
             "scalarization": self.scalarization.__name__,
+            "seed": self.seed,
         }
 
     def train(

--- a/morl_baselines/single_policy/ser/mo_q_learning.py
+++ b/morl_baselines/single_policy/ser/mo_q_learning.py
@@ -10,7 +10,11 @@ from torch.utils.tensorboard import SummaryWriter
 from morl_baselines.common.model_based.tabular_model import TabularModel
 from morl_baselines.common.morl_algorithm import MOAgent, MOPolicy
 from morl_baselines.common.scalarization import weighted_sum
-from morl_baselines.common.utils import linearly_decaying_value, log_episode_info
+from morl_baselines.common.utils import (
+    linearly_decaying_value,
+    log_episode_info,
+    seed_everything,
+)
 
 
 class MOQLearning(MOPolicy, MOAgent):
@@ -69,7 +73,8 @@ class MOQLearning(MOPolicy, MOAgent):
         self.id = id
         self.seed = seed
         if self.seed is not None:
-            np.random.seed(self.seed)
+            seed_everything(self.seed)
+
         if self.id is not None:
             self.idstr = f"_{self.id}"
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pygame >=2.1.0",
     "scipy >=1.7.3",
     "pymoo >=0.6.0",
-    "wandb",
+    "wandb >=0.13.11",
     "seaborn",
     "tensorboard",
     "cvxpy",

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -41,7 +41,7 @@ def test_pql():
     )
 
     # Training
-    pf = agent.train(num_episodes=1000, log_every=100, action_eval="hypervolume", eval_ref_point=ref_point)
+    pf = agent.train(total_timesteps=1000, log_every=100, action_eval="hypervolume", eval_ref_point=ref_point)
     assert len(pf) > 0
 
     # Policy following
@@ -104,7 +104,7 @@ def test_mp_moql():
         epsilon_decay_steps=int(1e3),
         log=False,
     )
-    agent.train(eval_env=eval_env, ref_point=np.array([0.0, -25.0]), num_iterations=1, timesteps_per_iteration=1000)
+    agent.train(eval_env=eval_env, ref_point=np.array([0.0, -25.0]), total_timesteps=2000, timesteps_per_iteration=1000)
 
     front = agent.linear_support.ccs
     assert len(front) > 0
@@ -215,16 +215,14 @@ def test_pgmorl():
     env_id = "mo-mountaincarcontinuous-v0"
     algo = PGMORL(
         env_id=env_id,
-        ref_point=np.array([0.0, 0.0]),
         num_envs=4,
         pop_size=6,
         warmup_iterations=2,
         evolutionary_iterations=2,
         num_weight_candidates=5,
-        limit_env_steps=int(1e4),
         log=False,
     )
-    algo.train()
+    algo.train(total_timesteps=int(1e4), ref_point=np.array([0.0, 0.0]))
     env = make_env(env_id, 422, 1, "PGMORL_test", gamma=0.995)()  # idx != 0 to avoid taking videos
 
     # Execution of trained policies
@@ -250,12 +248,11 @@ def test_pcn():
     )
 
     agent.train(
-        env,
+        total_timesteps=10,
         ref_point=np.array([0, 0, -200.0]),
         num_er_episodes=1,
         max_buffer_size=50,
         num_model_updates=50,
-        total_time_steps=10,
         max_return=np.array([1.5, 1.5, -0.0]),
     )
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -215,6 +215,7 @@ def test_pgmorl():
     env_id = "mo-mountaincarcontinuous-v0"
     algo = PGMORL(
         env_id=env_id,
+        origin=np.array([0.0, 0.0]),
         num_envs=4,
         pop_size=6,
         warmup_iterations=2,
@@ -254,6 +255,7 @@ def test_pcn():
         max_buffer_size=50,
         num_model_updates=50,
         max_return=np.array([1.5, 1.5, -0.0]),
+        eval_env=env,
     )
 
     agent.set_desired_return_and_horizon(np.array([1.5, 1.5, -0.0]), 100)


### PR DESCRIPTION
Relates to #12 

Wishlist:
- [x] Explicit seeds
- [x] Explicit wandb entity
- [x]  Shell script: algo-name, env-id, gamma, wandb entity, timesteps, seed
- [x] standardize algorithms init and train to take parameters above
- [x] [openrlbenchmark](https://github.com/openrlbenchmark/openrlbenchmark) stored run and extract plot

Example plot generated using this query on `openrlbenchmark` CLI:
```
 python -m openrlbenchmark.rlops \
    --filters '?we=openrlbenchmark&wpn=MORL-Baselines&ceik=env_id&cen=algo&metric=eval/eum' \
        'PCN' \
        'MultiPolicy MO Q-Learning' \
        'Envelope' \
    --env-ids deep-sea-treasure-v0 deep-sea-treasure-concave-v0 \
    --ncols 2 \
    --ncols-legend 1 \
    --output-filename compare.png \
    --report \
    --scan-history
```
![image](https://user-images.githubusercontent.com/11799929/224074706-0faacf8c-9449-4422-bf39-9d722d48d2e3.png)
