### PR TITLE
Fix bug in track_policy function that would result in an infinite loop

### DIFF
--- a/morl_baselines/multi_policy/pareto_q_learning/pql.py
+++ b/morl_baselines/multi_policy/pareto_q_learning/pql.py
@@ -245,7 +245,7 @@ class PQL(MOAgent):
 
         Args:
             vec (array_like): The return vector to track.
-            tol (float, optional): The tolerance for the return vector. (Default value = 1e-3) 
+            tol (float, optional): The tolerance for the return vector. (Default value = 1e-3)
         """
         target = np.array(vec)
         state, _ = self.env.reset()


### PR DESCRIPTION
I fixed a bug in the ``track_policy`` function that would lead the agent to cycle continuously when no close enough vector could be found. Now, a single pass is made over all Q-sets and the closest vector is returned as the new target. I also made a small optimisation that makes the agent break out of the loop when a vector is found that matches close enough, to avoid having to do an exhaustive search when possible.