### PR TITLE
Fix PGMORL evaluation

### DIFF
--- a/benchmark/launch_experiment.py
+++ b/benchmark/launch_experiment.py
@@ -160,6 +160,7 @@ def main():
     if args.algo == "pgmorl":
         # PGMORL creates its own environments because it requires wrappers
         print(f"Instantiating {args.algo} on {args.env_id}")
+        eval_env = mo_gym.make(args.env_id)
         algo = ALGOS[args.algo](
             env_id=args.env_id,
             origin=np.array(args.ref_point),
@@ -174,6 +175,7 @@ def main():
         print("Training starts... Let's roll!")
         algo.train(
             total_timesteps=args.num_timesteps,
+            eval_env=eval_env,
             ref_point=np.array(args.ref_point),
             known_pareto_front=None,
             **args.train_hyperparams,

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -20,7 +20,6 @@ from morl_baselines.multi_policy.pareto_q_learning.pql import PQL
 from morl_baselines.multi_policy.pcn.pcn import PCN
 from morl_baselines.multi_policy.pgmorl.pgmorl import PGMORL
 from morl_baselines.single_policy.esr.eupg import EUPG
-from morl_baselines.single_policy.ser.mo_ppo import make_env
 from morl_baselines.single_policy.ser.mo_q_learning import MOQLearning
 
 
@@ -213,6 +212,7 @@ def test_gpi_pd_continuous_action():
 # This test is a bit long to execute, idk what to do with it.
 def test_pgmorl():
     env_id = "mo-mountaincarcontinuous-v0"
+    eval_env = mo_gym.make(env_id)
     algo = PGMORL(
         env_id=env_id,
         origin=np.array([0.0, 0.0]),
@@ -223,13 +223,12 @@ def test_pgmorl():
         num_weight_candidates=5,
         log=False,
     )
-    algo.train(total_timesteps=int(1e4), ref_point=np.array([0.0, 0.0]))
-    env = make_env(env_id, 422, 1, "PGMORL_test", gamma=0.995)()  # idx != 0 to avoid taking videos
+    algo.train(eval_env=eval_env, total_timesteps=int(1e4), ref_point=np.array([0.0, 0.0]))
 
     # Execution of trained policies
     for a in algo.archive.individuals:
         scalarized, discounted_scalarized, reward, discounted_reward = eval_mo(
-            agent=a, env=env, w=np.array([1.0, 1.0]), render=False
+            agent=a, env=eval_env, w=np.array([1.0, 1.0]), render=False
         )
         assert scalarized != 0
         assert discounted_scalarized != 0


### PR DESCRIPTION
The evaluation was using the training environments, which are doing normalization and reward clipping, leading to false pareto front.