### PR TITLE
Use deterministic policies when evaluating PCN

### DIFF
--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -254,7 +254,7 @@ class PCN(MOAgent, MOPolicy):
         desired_return = np.float32(desired_return)
         return desired_return, desired_horizon
 
-    def _act(self, obs: np.ndarray, desired_return, desired_horizon, eval_mode = False) -> int:
+    def _act(self, obs: np.ndarray, desired_return, desired_horizon, eval_mode=False) -> int:
         log_probs = self.model(
             th.tensor([obs]).float().to(self.device),
             th.tensor([desired_return]).float().to(self.device),
@@ -267,7 +267,7 @@ class PCN(MOAgent, MOPolicy):
             action = self.np_random.choice(np.arange(len(log_probs)), p=np.exp(log_probs))
         return action
 
-    def _run_episode(self, env, desired_return, desired_horizon, max_return, eval_mode = False):
+    def _run_episode(self, env, desired_return, desired_horizon, max_return, eval_mode=False):
         transitions = []
         obs, _ = env.reset()
         done = False
@@ -312,7 +312,7 @@ class PCN(MOAgent, MOPolicy):
         horizons = np.float32(horizons)
         e_returns = []
         for i in range(n):
-            transitions = self._run_episode(env, returns[i], np.float32(horizons[i] - 2), max_return, eval_mode = True)
+            transitions = self._run_episode(env, returns[i], np.float32(horizons[i] - 2), max_return, eval_mode=True)
             # compute return
             for i in reversed(range(len(transitions) - 1)):
                 transitions[i].reward += self.gamma * transitions[i + 1].reward


### PR DESCRIPTION
According to [PCN paper](https://www.ifaamas.org/Proceedings/aamas2022/pdfs/p1110.pdf), "at execution time — i.e., after the training process — we use a deterministic policy by systematically selecting the action with the highest confidence"  however current implementation always uses sampled actions