### PR TITLE
Parallel Hyperparameter Search

### DIFF
--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -48,7 +48,7 @@ def parse_args():
 
     # If num_workers is None, will use the number of processors on the machine, multiplied by 5
     # https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor
-    parser.add_argument("num_workers", type=int, help="Number of workers to use for the sweep", default=None)
+    parser.add_argument("--num-workers", type=int, help="Number of workers to use for the sweep", default=None)
 
     parser.add_argument(
         "--seed", type=int, help="Random seed to start from, seeds will be in [seed, seed+num-seeds)", default=10
@@ -145,6 +145,8 @@ def train(worker_data: WorkerInitData) -> WorkerDoneData:
 def main():
     # Get the sweep id
     sweep_run = wandb.init()
+
+    print("Num workers: {}".format(args.num_workers))
 
     # Workers will be blocked on a queue waiting to start
     with ProcessPoolExecutor(max_workers=args.num_workers) as executor:

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -46,6 +46,10 @@ def parse_args():
     parser.add_argument("--sweep-count", type=int, help="Number of trials to do in the sweep worker", default=10)
     parser.add_argument("--num-seeds", type=int, help="Number of seeds to use for the sweep", default=3)
 
+    # If num_workers is None, will use the number of processors on the machine, multiplied by 5
+    # https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor
+    parser.add_argument("num_workers", type=int, help="Number of workers to use for the sweep", default=None)
+
     parser.add_argument(
         "--seed", type=int, help="Random seed to start from, seeds will be in [seed, seed+num-seeds)", default=10
     )
@@ -142,12 +146,8 @@ def main():
     # Get the sweep id
     sweep_run = wandb.init()
 
-    # Get the number of CPUs available
-    num_cpus = cpu_count()
-    print(f"Spinning up {num_cpus} workers")
-
     # Workers will be blocked on a queue waiting to start
-    with ProcessPoolExecutor(max_workers=num_cpus) as executor:
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
         futures = []
         for num in range(args.num_seeds):
             # Get the seed for the worker

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -142,8 +142,12 @@ def main():
     # Get the sweep id
     sweep_run = wandb.init()
 
+    # Get the number of CPUs available
+    num_cpus = cpu_count()
+    print(f"Spinning up {num_cpus} workers")
+
     # Workers will be blocked on a queue waiting to start
-    with ProcessPoolExecutor(max_workers=cpu_count()) as executor:
+    with ProcessPoolExecutor(max_workers=num_cpus) as executor:
         futures = []
         for num in range(args.num_seeds):
             # Get the seed for the worker

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -56,7 +56,7 @@ def parse_args():
         "--devices",
         type=str,
         nargs="+",
-        help="List of devices assigned to workers, e.g., 'cuda:0 cuda:1 cpu'. If not provided, defaults to 'cpu'.",
+        help="List of devices assigned to workers, e.g., 'cuda:0 cuda:1 cpu'. If not provided, defaults to 'auto'.",
         default=None,
     )
 

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -19,6 +19,7 @@ from morl_baselines.common.experiments import (
 )
 from morl_baselines.common.utils import reset_wandb_env
 
+
 @dataclass
 class WorkerInitData:
     sweep_id: str
@@ -26,9 +27,11 @@ class WorkerInitData:
     config: dict
     worker_num: int
 
+
 @dataclass
 class WorkerDoneData:
     hypervolume: float
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -76,6 +79,7 @@ def parse_args():
 
     return args
 
+
 def train(worker_data: WorkerInitData) -> WorkerDoneData:
     # Reset the wandb environment variables
     reset_wandb_env()
@@ -91,7 +95,7 @@ def train(worker_data: WorkerInitData) -> WorkerDoneData:
     torch.set_num_threads(1)
 
     # Assign the worker to a GPU if available in a round robin fashion
-    device = f'cuda:{worker_num % torch.cuda.device_count()}' if torch.cuda.is_available() else 'cpu'
+    device = f"cuda:{worker_num % torch.cuda.device_count()}" if torch.cuda.is_available() else "cpu"
     print("Spinning up worker {}".format(worker_num) + f" on device {device}")
 
     # Set the seed

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -104,8 +104,6 @@ def train(worker_data: WorkerInitData) -> WorkerDoneData:
     # If we launch multiple workers, then they will fight for the CPU.
     th.set_num_threads(1)
 
-    print("Spinning up worker {}".format(worker_num) + f" on device {device}")
-
     # Set the seed
     seed_everything(seed)
 
@@ -172,6 +170,7 @@ def main():
             seed = seeds[num]
             # Get the device for the worker
             device = args.devices[num] if args.devices else "auto"
+            print("Spinning up worker {}".format(num) + f" on device {device}")
             # Add the worker to the queue
             futures.append(
                 executor.submit(

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from concurrent.futures import ProcessPoolExecutor
+from multiprocessing import cpu_count
 from dataclasses import dataclass
 
 import mo_gymnasium as mo_gym
@@ -17,7 +18,6 @@ from morl_baselines.common.experiments import (
 )
 from morl_baselines.common.utils import reset_wandb_env
 
-
 @dataclass
 class WorkerInitData:
     sweep_id: str
@@ -25,11 +25,9 @@ class WorkerInitData:
     config: dict
     worker_num: int
 
-
 @dataclass
 class WorkerDoneData:
     hypervolume: float
-
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -140,9 +138,8 @@ def main():
     # Get the sweep id
     sweep_run = wandb.init()
 
-    # Spin up workers before calling wandb.init()
     # Workers will be blocked on a queue waiting to start
-    with ProcessPoolExecutor(max_workers=args.num_seeds) as executor:
+    with ProcessPoolExecutor(max_workers=cpu_count()) as executor:
         futures = []
         for num in range(args.num_seeds):
             # print("Spinning up worker {}".format(num))

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -56,7 +56,7 @@ def parse_args():
         "--devices",
         type=str,
         nargs="+",
-        help="List of devices to use. Each device is assigned to a worker, e.g., 'cuda:0 cuda:1 cpu'. If not provided, defaults to 'auto'.",
+        help="List of devices to use. Each device is assigned to a worker, e.g., 'cuda:0 cuda:1 cpu'. If not provided, defaults to 'auto' for each worker.",
         default=None,
     )
 

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -100,8 +100,7 @@ def train(worker_data: WorkerInitData) -> WorkerDoneData:
     device = worker_data.device
 
     # Set the number of threads to one.
-    # Otherwise, PyTorch will use all the available cores to run computations on CPU.
-    # If we launch multiple workers, then they will fight for the CPU.
+    # Otherwise, PyTorch will use all the available cores to run computations on CPU which will slow down the training.
     th.set_num_threads(1)
 
     # Set the seed

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -45,7 +45,7 @@ def parse_args():
     parser.add_argument("--wandb-entity", type=str, help="Wandb entity to use for the sweep", required=False)
     parser.add_argument("--project-name", type=str, help="Project name to use for the sweep", default="MORL-Baselines")
 
-    parser.add_argument("--sweep-count", type=int, help="Number of trials to do in the sweep worker", default=10)
+    parser.add_argument("--sweep-count", type=int, help="Number of hyperparameter search trials to run", default=10)
     parser.add_argument("--num-seeds", type=int, help="Number of seeds to use for the sweep", default=3)
 
     # If num_workers is None, will use the number of processors on the machine, multiplied by 5
@@ -56,7 +56,7 @@ def parse_args():
         "--devices",
         type=str,
         nargs="+",
-        help="List of devices assigned to workers, e.g., 'cuda:0 cuda:1 cpu'. If not provided, defaults to 'auto'.",
+        help="List of devices to use. Each device is assigned to a worker, e.g., 'cuda:0 cuda:1 cpu'. If not provided, defaults to 'auto'.",
         default=None,
     )
 
@@ -161,6 +161,8 @@ def train(worker_data: WorkerInitData) -> WorkerDoneData:
 def main():
     # Get the sweep id
     sweep_run = wandb.init()
+
+    print("Num workers: {}".format(args.num_workers))
 
     # Workers will be blocked on a queue waiting to start
     with ProcessPoolExecutor(max_workers=args.num_workers) as executor:

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 from concurrent.futures import ProcessPoolExecutor
-from multiprocessing import cpu_count
 from dataclasses import dataclass
 
 import numpy as np
@@ -87,6 +86,11 @@ def train(worker_data: WorkerInitData) -> WorkerDoneData:
     config = worker_data.config
     worker_num = worker_data.worker_num
     device = worker_data.device
+
+    # Set the number of threads
+    # Otherwise, PyTorch will use all the available cores to run computations on CPU.
+    # So if we launch multiple processes, then they will fight for the CPU.
+    torch.set_num_threads(1)
 
     # Set the seed
     seed_everything(seed)

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -48,9 +48,7 @@ def parse_args():
     parser.add_argument("--sweep-count", type=int, help="Number of hyperparameter search trials to run", default=10)
     parser.add_argument("--num-seeds", type=int, help="Number of seeds to use for the sweep", default=3)
 
-    # If num_workers is None, will use the number of processors on the machine, multiplied by 5
-    # https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor
-    parser.add_argument("--num-workers", type=int, help="Number of workers to use for the sweep", default=None)
+    parser.add_argument("--num-workers", type=int, help="Number of workers to use for the sweep", default=3)
 
     parser.add_argument(
         "--devices",

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -147,7 +147,7 @@ def main():
     sweep_run = wandb.init()
 
     # Workers will be blocked on a queue waiting to start
-    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+    with ProcessPoolExecutor(max_workers=args.num_workers) as executor:
         futures = []
         for num in range(args.num_seeds):
             # Get the seed for the worker

--- a/experiments/hyperparameter_search/launch_sweep.py
+++ b/experiments/hyperparameter_search/launch_sweep.py
@@ -98,7 +98,7 @@ def train(worker_data: WorkerInitData) -> WorkerDoneData:
     device = worker_data.device
 
     # Set the number of threads to one.
-    # Otherwise, PyTorch will use all the available cores to run computations on CPU which will slow down the training.
+    # Otherwise, PyTorch will use all the available cores which will slow down the training.
     th.set_num_threads(1)
 
     # Set the seed

--- a/morl_baselines/common/prioritized_buffer.py
+++ b/morl_baselines/common/prioritized_buffer.py
@@ -104,10 +104,7 @@ class PrioritizedReplayBuffer:
             min_priority: Minimum priority of the buffer
         """
         self.max_size = max_size
-        (
-            self.ptr,
-            self.size,
-        ) = (
+        (self.ptr, self.size,) = (
             0,
             0,
         )

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -169,8 +169,6 @@ class Envelope(MOPolicy, MOAgent):
         self.final_homotopy_lambda = final_homotopy_lambda
         self.homotopy_decay_steps = homotopy_decay_steps
 
-        print("Envelope device: ", self.device)
-
         self.q_net = QNet(self.observation_shape, self.action_dim, self.reward_dim, net_arch=net_arch).to(self.device)
         self.target_q_net = QNet(self.observation_shape, self.action_dim, self.reward_dim, net_arch=net_arch).to(self.device)
         self.target_q_net.load_state_dict(self.q_net.state_dict())

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -148,7 +148,7 @@ class Envelope(MOPolicy, MOAgent):
             group: The wandb group to use for logging.
         """
         MOAgent.__init__(self, env, device=device, seed=seed)
-        MOPolicy.__init__(self, device)
+        MOPolicy.__init__(self, device=device)
         self.learning_rate = learning_rate
         self.initial_epsilon = initial_epsilon
         self.epsilon = initial_epsilon
@@ -168,6 +168,8 @@ class Envelope(MOPolicy, MOAgent):
         self.initial_homotopy_lambda = initial_homotopy_lambda
         self.final_homotopy_lambda = final_homotopy_lambda
         self.homotopy_decay_steps = homotopy_decay_steps
+
+        print("Envelope device: ", self.device)
 
         self.q_net = QNet(self.observation_shape, self.action_dim, self.reward_dim, net_arch=net_arch).to(self.device)
         self.target_q_net = QNet(self.observation_shape, self.action_dim, self.reward_dim, net_arch=net_arch).to(self.device)

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -125,7 +125,7 @@ class PCN(MOAgent, MOPolicy):
             device (Union[th.device, str], optional): Device to use. Defaults to "auto".
         """
         MOAgent.__init__(self, env, device=device, seed=seed)
-        MOPolicy.__init__(self, device)
+        MOPolicy.__init__(self, device=device)
 
         self.experience_replay = []  # List of (distance, time_step, transition)
         self.batch_size = batch_size


### PR DESCRIPTION
## PR Description

This PR makes hyperparameter search more scalable by running the training loop for each agent in parallel. This is especially useful when running the search on a cluster (e.g. Slurm).

- Assign workers to devices such as GPU / CPU. The list of devices can now be provided as an argument.
- Fix an issue when we were not setting number of threads for each process. This basically made the CPU parallelization even slower when a sequential run. Now this is fixed. [Link to the issue](https://discuss.pytorch.org/t/multiple-networks-running-in-parallel-on-different-cpus/70482).
- Add `num_workers` parameter to define the size of the pool of processes. Still not sure about this one though as we still need to wait for all of the workers from the same iteration so that we can get the hypervolume. So maybe we can just spawn the same number of processes as `num_seeds`.
- There was a bug in one of the initializers of the **Envelope** and **PCN** algorithms, where we were passing `device` as an `id` making it essentialy always default to the same device.
 
## TODO:
- [ ]  True GPU parallelization of policy evaluation / model update step.
- [x] Add examples of runs with different configurations 


## Example Configs on a Slurm Cluster

`Using 4 GPUs + 4 workers`

```bash
#SBATCH --nodes=1 # node count
#SBATCH --ntasks=1 # total number of tasks across all nodes

#SBATCH --cpus-per-task 4 # number of processes
#SBATCH -G 4

python experiments/hyperparameter_search/launch_sweep.py \
--algo envelope \
--env-id minecart-v0 \
--sweep-count 100 \
--seed 10 \
--num-seeds 4 \
--num-workers 4 \
--devices cuda:0 cuda:1 cuda:2 cuda:3 
```

`Using 4 CPUs + 4 workers` 

```bash
#SBATCH --nodes=1 # node count
#SBATCH --ntasks=1 # total number of tasks across all nodes

#SBATCH --cpus-per-task 4 # number of processes

python experiments/hyperparameter_search/launch_sweep.py \
--algo envelope \
--env-id minecart-v0 \
--sweep-count 100 \
--seed 10 \
--num-seeds 4 \
--num-workers 4 
```
Each worker will use `auto` and then each algo instance will default to `cpu` as CUDA is not available.

## Example Runs on a Slurm Cluster
Example Runs:
| &nbsp;&nbsp;Workers&nbsp;&nbsp; | &nbsp;&nbsp;CPUs &nbsp;&nbsp; |GPUs| CPU Usage | GPU Usage       | Sweeps |
|--------:|----:|----:|----------:|----------------:|-------:|
|       4 |   4 |   0 |    94.88% |       N/A       |     18 |
|       4 |   1 |   0 |    95.55% |       N/A       |     15 |
|       1 |   1 |   0 |    25.03% |       N/A       |     15 |
|       4 |   4 |   1 |    18.78% |       99%       |      5 |
|       4 |   4 |   4 |    31.07% |9%<br /> 11%<br /> 12%<br /> 10%|      5 |
|       4 |   1 |   4 |    98.85% |4%<br /> 5%<br /> 5%<br /> 5%   |     13 |

- `Workers` corresponds to `num_workers`, `CPUs` corresponds to `--cpus-per-task`, `GPUs` corresponds to `-G`
- Number of seeds set to 4 (i.e. training 4 agents).
- GPU Usage measured through `srun -s --jobid <job-id> --pty nvidia-smi` command while running the job.
- CPU Usage measured via `seff`command after finishing the job.
- CPU Config:  Intel Broadwell or Skylake processors.
- GPU Config: Tesla V100.
- Each run lasted 10 hours.
