### PR TITLE
Adding cardinality metric

### DIFF
--- a/docs/algos/performances.md
+++ b/docs/algos/performances.md
@@ -13,6 +13,7 @@ For single-policy algorithms, the metric used will be the scalarized return of t
 ### Multi-policy algorithms
 For multi-policy algorithms, we propose to rely on various metrics to assess the quality of the **discounted** Pareto Fronts (PF) or Convex Coverage Set (CCS). In general, we want to have a metric that is able to assess the convergence of the PF, a metric that is able to assess the diversity of the PF, and a hybrid metric assessing both. The metrics are implemented in `common/performance_indicators`. We propose to use the following metrics:
 * (Diversity) Sparsity: average distance between each consecutive point in the PF. From the PGMORL paper [1]. Keyword: `eval/sparsity`.
+* (Diversity) Cardinality: number of points in the PF. Keyword: `eval/cardinality`.
 * (Convergence) IGD: a SOTA metric from Multi-Objective Optimization (MOO) literature. It requires a reference PF that we can compute a posteriori. That is, we do a merge of all the PFs found by the method and compute the IGD with respect to this reference PF. Keyword: `eval/igd`.
 * (Hybrid) Hypervolume: a SOTA metric from MOO and MORL literature. Keyword: `eval/hypervolume`.
 

--- a/morl_baselines/common/evaluation.py
+++ b/morl_baselines/common/evaluation.py
@@ -10,6 +10,7 @@ from pymoo.util.ref_dirs import get_reference_directions
 
 from morl_baselines.common.pareto import filter_pareto_dominated
 from morl_baselines.common.performance_indicators import (
+    cardinality,
     expected_utility,
     hypervolume,
     igd,
@@ -168,12 +169,14 @@ def log_all_multi_policy_metrics(
     hv = hypervolume(hv_ref_point, filtered_front)
     sp = sparsity(filtered_front)
     eum = expected_utility(filtered_front, weights_set=equally_spaced_weights(reward_dim, n_sample_weights))
+    card = cardinality(filtered_front)
 
     wandb.log(
         {
             "eval/hypervolume": hv,
             "eval/sparsity": sp,
             "eval/eum": eum,
+            "eval/cardinality": card,
             "global_step": global_step,
         },
         commit=False,

--- a/morl_baselines/common/performance_indicators.py
+++ b/morl_baselines/common/performance_indicators.py
@@ -87,6 +87,20 @@ def expected_utility(front: List[np.ndarray], weights_set: List[np.ndarray], uti
     return np.mean(np.array(maxs), axis=0)
 
 
+def cardinality(front: List[np.ndarray]) -> float:
+    """Cardinality Metric.
+
+    Cardinality of the Pareto front approximation.
+
+    Args:
+        front: current pareto front to compute the cardinality on
+
+    Returns:
+        float: cardinality metric
+    """
+    return len(front)
+
+
 def maximum_utility_loss(
     front: List[np.ndarray], reference_set: List[np.ndarray], weights_set: np.ndarray, utility: Callable = np.dot
 ) -> float:


### PR DESCRIPTION
Some metrics can be very good for a small amount of points in the PF, e.g. HV, EUM, Sparsity. 

I think this simple indicator already helps in mitigating such scenarios in problems with >3objs, where we cannot plot the front.

It also has the advantage of not requiring more ref points (contrary to spread).