### PR TITLE
Fix EUPG's inconsistent expansion of observations

### DIFF
--- a/morl_baselines/single_policy/esr/eupg.py
+++ b/morl_baselines/single_policy/esr/eupg.py
@@ -290,9 +290,12 @@ class EUPG(MOPolicy, MOAgent):
         for _ in range(1, total_timesteps + 1):
             self.global_step += 1
 
+            if type(obs) is int:
+                obs = [obs]
+
             with th.no_grad():
                 # For training, takes action according to the policy
-                action = self.__choose_action(th.Tensor([obs]).to(self.device), accrued_reward_tensor)
+                action = self.__choose_action(th.Tensor(obs).to(self.device), accrued_reward_tensor)
             next_obs, vec_reward, terminated, truncated, info = self.env.step(action)
 
             # Memory update


### PR DESCRIPTION
Fix for issue #118


I conditioned the expansion on the type to mimic what is done in the eval function. This "future-proofs" this algorithm for environments with a spaces.Discrete observation space. Ideally either all algorithms would have something similar or all MO-Gymnasium tabular environments would have a standardized spaces.Box observation space.