### PR TITLE
In GPI-LS for continuous action, use GPI only for selecting weights as default

### DIFF
--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -96,7 +96,7 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
         delay_policy_update: int = 2,
         learning_starts: int = 100,
         gradient_updates: int = 20,
-        use_gpi: bool = True,
+        use_gpi: bool = False,  # In the continuous action case, GPI is only used to selected weights.
         policy_noise: float = 0.2,
         noise_clip: float = 0.5,
         per: bool = True,


### PR DESCRIPTION
In the continuous action case, GPI can only be approximated and is not completely equivalent to the discrete case. I have realized that GPI-LS in the continuous action case works much better if `use_gpi=False`. That is, GPI is only used in the selection of the new weights of the iteration, and not to evaluate the algorithm.

This also reduces the training time, since the time to evaluate an action becomes smaller.