### PR TITLE
fix mario wrappers not compatible with gymnasium==1.0.0 and fix mario video recording

### DIFF
--- a/experiments/benchmark/launch_experiment.py
+++ b/experiments/benchmark/launch_experiment.py
@@ -16,7 +16,7 @@ import numpy as np
 import requests
 from gym_super_mario_bros.actions import SIMPLE_MOVEMENT
 from gymnasium.wrappers import FlattenObservation, RecordVideo
-from mo_gymnasium.wrappers import MORecordEpisodeStatistics
+from mo_gymnasium.wrappers import MORecordEpisodeStatistics, RecordMarioVideo
 
 from morl_baselines.common.evaluation import seed_everything
 from morl_baselines.common.experiments import (
@@ -160,8 +160,8 @@ def main():
 
             def wrap_mario(env):
                 from gymnasium.wrappers import (
-                    FrameStack,
-                    GrayScaleObservation,
+                    FrameStackObservation,
+                    GrayscaleObservation,
                     ResizeObservation,
                     TimeLimit,
                 )
@@ -171,8 +171,8 @@ def main():
                 env = JoypadSpace(env, SIMPLE_MOVEMENT)
                 env = MOMaxAndSkipObservation(env, skip=4)
                 env = ResizeObservation(env, (84, 84))
-                env = GrayScaleObservation(env)
-                env = FrameStack(env, 4)
+                env = GrayscaleObservation(env)
+                env = FrameStackObservation(env, 4)
                 env = TimeLimit(env, max_episode_steps=1000)
                 return env
 
@@ -180,11 +180,18 @@ def main():
             eval_env = wrap_mario(eval_env)
 
         if args.record_video:
-            eval_env = RecordVideo(
-                eval_env,
-                video_folder=f"videos/{args.algo}-{args.env_id}",
-                episode_trigger=lambda ep: ep % args.record_video_ep_freq == 0,
-            )
+            if "mario" in args.env_id:
+                eval_env = RecordMarioVideo(
+                    eval_env,
+                    video_folder=f"videos/{args.algo}-{args.env_id}",
+                    episode_trigger=lambda ep: ep % args.record_video_ep_freq == 0,
+                )
+            else:
+                eval_env = RecordVideo(
+                    eval_env,
+                    video_folder=f"videos/{args.algo}-{args.env_id}",
+                    episode_trigger=lambda ep: ep % args.record_video_ep_freq == 0,
+                )
 
         print(f"Instantiating {args.algo} on {args.env_id}")
         if args.algo == "ols":


### PR DESCRIPTION
Few fixes:
- Gymnasium==1.0.0 renamed `FrameStack` to `FrameStackObservation`
- Gymnasium==1.0.0 renamed `GrayScaleObservation` to `GrayscaleObservation` (small letter 's')
- Assuming this PR https://github.com/Farama-Foundation/MO-Gymnasium/pull/116 gets merged, add `RecordMarioVideo` to record videos properly for MOSuperMarioBros

Feel free to revert changes regarding the third point if you want to make the pushes more modular. Tested with:
```bash
python3 -u experiments/benchmark/launch_experiment.py \
--algo envelope \
--env-id mo-supermario-v0 \
--num-timesteps 100000 \
--seed 0 \
--gamma 0.99 \
--auto-tag True \
--ref-point -100.0 -100.0 -100.0 -100.0 \
--init-hyperparams "net_arch:[512, 512]" batch_size:32 num_sample_w:8 per:True initial_epsilon:0.2 final_epsilon:0.01 epsilon_decay_steps:10000 buffer_size:100000 gradient_updates:1 target_net_update_freq:1000 initial_homotopy_lambda:0.95 \
--train-hyperparams num_eval_weights_for_front:32 num_eval_episodes_for_front:1 eval_freq:5 \ # low eval_freq to see vids
--record-video \
--record-video-ep-freq 1 \
```

https://github.com/user-attachments/assets/07e07879-96a6-4218-bea8-03419c9d2035


