### PR TITLE
MORecordEpisodeStatistics-logging-fix

### DIFF
--- a/morl_baselines/multi_policy/capql/capql.py
+++ b/morl_baselines/multi_policy/capql/capql.py
@@ -455,7 +455,7 @@ class CAPQL(MOAgent, MOPolicy):
                 self.update()
 
             if terminated or truncated:
-                obs, info = self.env.reset()
+                obs, _ = self.env.reset()
                 self.num_episodes += 1
 
                 if self.log and "episode" in info.keys():

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -575,7 +575,7 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
                     plot.close()
 
             if terminated or truncated:
-                obs, info = self.env.reset()
+                obs, _ = self.env.reset()
                 self.num_episodes += 1
 
                 if self.log and "episode" in info.keys():

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -375,11 +375,11 @@ class PCN(MOAgent, MOPolicy):
         distances = np.linalg.norm(np.array(returns) - np.array(e_returns), axis=-1)
         return e_returns, np.array(returns), distances
 
-    def save(self, filename: str = "PCN_model", savedir: str = "weights"):
+    def save(self, filename: str = "PCN_model", save_dir: str = "weights"):
         """Save PCN."""
-        if not os.path.isdir(savedir):
-            os.makedirs(savedir)
-        th.save(self.model, f"{savedir}/{filename}.pt")
+        if not os.path.isdir(save_dir):
+            os.makedirs(save_dir)
+        th.save(self.model, f"{save_dir}/{filename}.pt")
 
     def train(
         self,

--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -375,11 +375,11 @@ class PCN(MOAgent, MOPolicy):
         distances = np.linalg.norm(np.array(returns) - np.array(e_returns), axis=-1)
         return e_returns, np.array(returns), distances
 
-    def save(self, filename: str = "PCN_model", save_dir: str = "weights"):
+    def save(self, filename: str = "PCN_model", savedir: str = "weights"):
         """Save PCN."""
-        if not os.path.isdir(save_dir):
-            os.makedirs(save_dir)
-        th.save(self.model, f"{save_dir}/{filename}.pt")
+        if not os.path.isdir(savedir):
+            os.makedirs(savedir)
+        th.save(self.model, f"{savedir}/{filename}.pt")
 
     def train(
         self,


### PR DESCRIPTION
Refactor: Fix episode info so it dose is not reset before logging. In order to have MORecordEpisodeStatistics and similar thing working.

see issue:
#141 

