### PR TITLE
Fix sorting individuals in performance buffer pgmorl

### DIFF
--- a/morl_baselines/multi_policy/pgmorl/pgmorl.py
+++ b/morl_baselines/multi_policy/pgmorl/pgmorl.py
@@ -276,7 +276,7 @@ class PerformanceBuffer2d:
             return
 
         inserted = False
-        # Inserts the new candidate at the right position in the bin, in accending order of the norm
+        # Inserts the new candidate at the right position in the bin, in ascending order of the norm
         for idx, existing_eval in enumerate(self.bins_evals[buffer_id]):
             existing_norm = np.linalg.norm(center_eval(existing_eval))
             if norm_eval < existing_norm:
@@ -348,7 +348,7 @@ class PerformanceBuffer3d:
                 max_dot, buffer_id = dot, i
 
         inserted = False
-        # Inserts the new candidate at the right position in the bin, in accending order of the norm
+        # Inserts the new candidate at the right position in the bin, in ascending order of the norm
         for idx, existing_eval in enumerate(self.bins_evals[buffer_id]):
             existing_norm = np.linalg.norm(center_eval(existing_eval))
             if norm_eval < existing_norm:


### PR DESCRIPTION
As discussed in issue #146, I changed the add function of the performance buffer to store the new candidate in the correct (asc) order in the bins. It will then properly remove the worst candidate from the bin when it is full.