### PR TITLE
fix: use global_step consistently across wandb logging

### DIFF
--- a/morl_baselines/common/evaluation.py
+++ b/morl_baselines/common/evaluation.py
@@ -174,20 +174,17 @@ def log_all_multi_policy_metrics(
     eum = expected_utility(filtered_front, weights_set=equally_spaced_weights(reward_dim, n_sample_weights))
     card = cardinality(filtered_front)
 
-    wandb.log(
-        {
-            "eval/hypervolume": hv,
-            "eval/eum": eum,
-            "eval/cardinality": card,
-            "global_step": global_step,
-        },
-        commit=False,
-    )
+    metrics = {
+        "eval/hypervolume": hv,
+        "eval/eum": eum,
+        "eval/cardinality": card,
+        "global_step": global_step,
+    }
     front = wandb.Table(
         columns=[f"objective_{i}" for i in range(1, reward_dim + 1)],
         data=[p.tolist() for p in filtered_front],
     )
-    wandb.log({"eval/front": front})
+    metrics["eval/front"] = front
 
     # If PF is known, log the additional metrics
     if ref_front is not None:
@@ -197,7 +194,10 @@ def log_all_multi_policy_metrics(
             reference_set=ref_front,
             weights_set=get_reference_directions("energy", reward_dim, n_sample_weights).astype(np.float32),
         )
-        wandb.log({"eval/igd": generational_distance, "eval/mul": mul})
+        metrics["eval/igd"] = generational_distance
+        metrics["eval/mul"] = mul
+
+    wandb.log(metrics)
 
 
 def seed_everything(seed: int):
@@ -257,21 +257,16 @@ def log_episode_info(
         idstr = "_" + str(id)
     else:
         idstr = ""
-    wandb.log(
-        {
-            f"charts{idstr}/timesteps_per_episode": episode_ts,
-            f"charts{idstr}/episode_time": episode_time,
-            f"metrics{idstr}/scalarized_episode_return": scal_return,
-            f"metrics{idstr}/discounted_scalarized_episode_return": disc_scal_return,
-            "global_step": global_timestep,
-        },
-        commit=False,
-    )
+    metrics = {
+        f"charts{idstr}/timesteps_per_episode": episode_ts,
+        f"charts{idstr}/episode_time": episode_time,
+        f"metrics{idstr}/scalarized_episode_return": scal_return,
+        f"metrics{idstr}/discounted_scalarized_episode_return": disc_scal_return,
+        "global_step": global_timestep,
+    }
 
     for i in range(episode_return.shape[0]):
-        wandb.log(
-            {
-                f"metrics{idstr}/episode_return_obj_{i}": episode_return[i],
-                f"metrics{idstr}/disc_episode_return_obj_{i}": disc_episode_return[i],
-            },
-        )
+        metrics[f"metrics{idstr}/episode_return_obj_{i}"] = episode_return[i]
+        metrics[f"metrics{idstr}/disc_episode_return_obj_{i}"] = disc_episode_return[i]
+    
+    wandb.log(metrics)

--- a/morl_baselines/common/morl_algorithm.py
+++ b/morl_baselines/common/morl_algorithm.py
@@ -67,20 +67,16 @@ class MOPolicy(ABC):
         else:
             idstr = f"_{self.id}"
 
-        wandb.log(
-            {
-                f"eval{idstr}/scalarized_return": scalarized_return,
-                f"eval{idstr}/scalarized_discounted_return": scalarized_discounted_return,
-                "global_step": self.global_step,
-            }
-        )
+        metrics = {
+            f"eval{idstr}/scalarized_return": scalarized_return,
+            f"eval{idstr}/scalarized_discounted_return": scalarized_discounted_return,
+            "global_step": self.global_step,
+        }
         for i in range(vec_return.shape[0]):
-            wandb.log(
-                {
-                    f"eval{idstr}/vec_{i}": vec_return[i],
-                    f"eval{idstr}/discounted_vec_{i}": discounted_vec_return[i],
-                },
-            )
+            metrics[f"eval{idstr}/vec_{i}"] = vec_return[i]
+            metrics[f"eval{idstr}/discounted_vec_{i}"] = discounted_vec_return[i]
+
+        wandb.log(metrics)
 
     def policy_eval(
         self,

--- a/morl_baselines/multi_policy/envelope/envelope.py
+++ b/morl_baselines/multi_policy/envelope/envelope.py
@@ -355,16 +355,15 @@ class Envelope(MOPolicy, MOAgent):
             )
 
         if self.log and self.global_step % 100 == 0:
-            wandb.log(
-                {
-                    "losses/critic_loss": np.mean(critic_losses),
-                    "metrics/epsilon": self.epsilon,
-                    "metrics/homotopy_lambda": self.homotopy_lambda,
-                    "global_step": self.global_step,
-                },
-            )
+            metrics = {
+                "losses/critic_loss": np.mean(critic_losses),
+                "metrics/epsilon": self.epsilon,
+                "metrics/homotopy_lambda": self.homotopy_lambda,
+                "global_step": self.global_step,
+            }
             if self.per:
-                wandb.log({"metrics/mean_priority": np.mean(priority)})
+                metrics["metrics/mean_priority"] = np.mean(priority)
+            wandb.log(metrics)
 
     @override
     def eval(self, obs: np.ndarray, w: np.ndarray) -> int:

--- a/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_continuous_action_jax.py
+++ b/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_continuous_action_jax.py
@@ -837,7 +837,7 @@ class GPILSContinuousAction(MOAgent, MOPolicy):
                 mean_gpi_returns_test_tasks = np.mean(
                     [np.dot(ew, q) for ew, q in zip(eval_weights, gpi_returns_test_tasks)], axis=0
                 )
-                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter})
+                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter, "global_step": self.global_step})
 
             # Checkpoint
             if checkpoints:

--- a/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_jax.py
+++ b/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_jax.py
@@ -822,7 +822,7 @@ class GPILS(MOAgent, MOPolicy):
                 mean_gpi_returns_test_tasks = np.mean(
                     [np.dot(ew, q) for ew, q in zip(eval_weights, gpi_returns_test_tasks)], axis=0
                 )
-                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter})
+                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter, "global_step": self.global_step})
 
             if checkpoints:
                 self.save(filename=f"GPI-LS {weight_selection_algo} iter={iter}")

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd.py
@@ -903,7 +903,7 @@ class GPIPD(MOPolicy, MOAgent):
                 mean_gpi_returns_test_tasks = np.mean(
                     [np.dot(ew, q) for ew, q in zip(eval_weights, gpi_returns_test_tasks)], axis=0
                 )
-                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter})
+                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter, "global_step": self.global_step})
 
             if checkpoints:
                 self.save(filename=f"GPI-PD {weight_selection_algo} iter={iter}", save_replay_buffer=False)

--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -694,7 +694,7 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
                 mean_gpi_returns_test_tasks = np.mean(
                     [np.dot(ew, q) for ew, q in zip(eval_weights, gpi_returns_test_tasks)], axis=0
                 )
-                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter})
+                wandb.log({"eval/Mean Utility - GPI": mean_gpi_returns_test_tasks, "iteration": iter, "global_step": self.global_step})
 
             # Checkpoint
             if checkpoints:


### PR DESCRIPTION
## Summary
This PR modifies multiple files across `morl_baselines` to correctly include `global_step` in all `wandb.log` calls, resolving an issue where the W&B dashboard defaults to logging by the sequentially auto-incrementing `step` instead of the actual `global_step` representing environment interactions.

## Problem
Closes #176
In several locations (e.g. `evaluation.py`, `morl_algorithm.py`, and algorithms like `envelope` and `gpi_pd`), multiple calls to `wandb.log` were either:
- Not using `commit=False` and immediately following a log call that had `global_step`
- Iteratively calling `wandb.log` without passing `global_step`
- Forgetting to include `global_step` alongside specific metrics entirely

This resulted in `global_step` becoming desynchronized with `step` on Weights & Biases, making x-axis matching difficult or impossible when viewing metrics for different evaluations.

## Solution
- Refactored `wandb.log()` calls into single, grouped `metrics` dictionaries per block before logging. 
- Ensured `global_step: global_timestep` or `global_step: self.global_step` is universally injected into the assembled `metrics` dictionary prior to submitting it to `wandb.log(metrics)`.

## Testing
- Code builds correctly.
- Mapped all `wandb.log` targets to confirm payload formats.

---
*This PR was created with AI assistance.*