### PR TITLE
Use np.ptp instead of array.ptp in PCN

### DIFF
--- a/morl_baselines/multi_policy/pcn/pcn.py
+++ b/morl_baselines/multi_policy/pcn/pcn.py
@@ -22,7 +22,7 @@ from morl_baselines.common.performance_indicators import hypervolume
 def crowding_distance(points):
     """Compute the crowding distance of a set of points."""
     # first normalize across dimensions
-    points = (points - points.min(axis=0)) / (points.ptp(axis=0) + 1e-8)
+    points = (points - points.min(axis=0)) / (np.ptp(points, axis=0) + 1e-8)
     # sort points per dimension
     dim_sorted = np.argsort(points, axis=0)
     point_sorted = np.take_along_axis(points, dim_sorted, axis=0)


### PR DESCRIPTION
The `ptp` method of the `np.ndarray` class was removed in NumPy 2.0. As a result, the Pareto-Conditioned Network (PCN) implementation fails in the helper function `crowding_distance` when NumPy 2.0 or newer is used.

This PR [replaces the call](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ndarray-and-scalar-methods) by `np.ptp(arr, ...)` so that the PCN implementation works correctly with recent NumPy versions.