### PR TITLE
MOQL: Use input weight vector in eval() for scalarization

### DIFF
--- a/morl_baselines/single_policy/ser/mo_q_learning.py
+++ b/morl_baselines/single_policy/ser/mo_q_learning.py
@@ -158,7 +158,10 @@ class MOQLearning(MOPolicy, MOAgent):
         if t_obs not in self.q_table:
             return int(self.env.action_space.sample())
         scalarized = np.array(
-            [self.scalarization(state_action_value, self.weights) for state_action_value in self.q_table[t_obs]]
+            [
+                self.scalarization(state_action_value, self.weights if w is None else w)
+                for state_action_value in self.q_table[t_obs]
+            ]
         )
         return int(np.argmax(scalarized))
 


### PR DESCRIPTION
Actions are sampled from multi-objective policies via the `eval` method, which takes as an input the observation and an optional weight vector. This allows adjusting the preference over objectives at test time.

In spite of this, the Multi-Objective Q Learning (MOQL) implementation ignored the input weight vector in `eval`, instead always using the `self.weights` vector used for scalarization during training. This means that e.g. `eval_mo` can yield wrong results if the provided weight vector is different to the one used during training, unless we manually overwrite the agent's `weights` attribute beforehand. Certainly, the learned Q-values are only optimal for the training-time scalarization, but it can be useful to evaluate the policy when changing the weights at test time.

This PR makes MOQL's `eval` method use the provided weight vector for scalarization. If not provided (`w is None`) the original `self.weights` vector is used instead.