### PR TITLE
Fix tensor device mismatch in GPIPDContinuousAction: Move idxes tensor to CPU on PER

### DIFF
--- a/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
+++ b/morl_baselines/multi_policy/gpi_pd/gpi_pd_continuous_action.py
@@ -414,7 +414,7 @@ class GPIPDContinuousAction(MOAgent, MOPolicy):
                 per = th.einsum("br,br->b", per, w[: len(idxes)])
                 priority = per.cpu().numpy().flatten()
                 priority = priority.clip(min=self.min_priority) ** self.alpha
-                self.replay_buffer.update_priorities(idxes, priority)
+                self.replay_buffer.update_priorities(idxes.cpu(), priority)
 
             for q_net, target_q_net in zip(self.q_nets, self.target_q_nets):
                 polyak_update(q_net.parameters(), target_q_net.parameters(), self.tau)


### PR DESCRIPTION
In `GPIPDContinuousAction.update`, the priorities of the replay buffer are updated when using Prioritized Experience Replay (PER). In particular, we call `replay_buffer.update_priorities(idxes, priority)` where both `idxes` and `priority` are PyTorch tensors. These tensors are stored in `self.device`, which is `th.device("cuda")` if available.

The problem is that, in `PrioritizedReplayBuffer`, `update_priorities` calls `self.tree.batch_set`, which in turn calls `np.unique` on the input indices. Since the indices are still a Tensor which may be stored on the GPU, a `TypeError` is thrown since the tensor must be on host (CPU) memory to be used by a NumPy function.

This PR fixes this error by moving the `idxes` array to CPU memory before the replay buffer update, just as is done with the `priority` tensor (`priority = per.cpu().numpy().flatten()`).