### PR TITLE
GPI-LS Jax: Use absolute path for model saving

### DIFF
--- a/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_continuous_action_jax.py
+++ b/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_continuous_action_jax.py
@@ -345,7 +345,7 @@ class GPILSContinuousAction(MOAgent, MOPolicy):
         filename = self.experiment_name if filename is None else filename
         orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
         save_args = orbax_utils.save_args_from_target(saved_params)
-        orbax_checkpointer.save(save_dir + filename, saved_params, save_args=save_args, force=True)
+        orbax_checkpointer.save(os.path.abspath(save_dir) + "/" + filename, saved_params, save_args=save_args, force=True)
 
     def load(self, path):
         """Load agent's parameters from the given path."""

--- a/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_jax.py
+++ b/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_jax.py
@@ -318,7 +318,7 @@ class GPILS(MOAgent, MOPolicy):
         filename = self.experiment_name if filename is None else filename
         orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
         save_args = orbax_utils.save_args_from_target(saved_params)
-        orbax_checkpointer.save(save_dir + filename, saved_params, save_args=save_args, force=True)
+        orbax_checkpointer.save(os.path.abspath(save_dir) + "/" + filename, saved_params, save_args=save_args, force=True)
 
     def load(self, path: str, step: Optional[int] = None):
         """Load the model parameters."""


### PR DESCRIPTION
When attempting to save a model checkpoint, the Jax implementations of GPI-LS fail with
```
ValueError: Checkpoint path should be absolute. Got weights/GPI-LS Jax iter=1.orbax-checkpoint-tmp
```
This PR ensures that the weight directory is [converted to an absolute path](https://docs.python.org/3/library/os.path.html#os.path.abspath) before being passed to the orbax checkpointer.