### PR TITLE
GPI-LS Jax: Fix loading of weight support from checkpoint

### DIFF
--- a/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_continuous_action_jax.py
+++ b/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_continuous_action_jax.py
@@ -361,7 +361,7 @@ class GPILSContinuousAction(MOAgent, MOPolicy):
 
         self.q_state = restored["q_net_state"]
         self.actor_state = restored["actor_state"]
-        self.weight_support = [w for w in restored["M"].values()]
+        self.weight_support = restored["M"]
 
     def sample_batch_experiences(self):
         """Samples a mini-batch of experiences."""

--- a/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_jax.py
+++ b/morl_baselines/multi_policy/gpi_ls_jax/gpi_ls_jax.py
@@ -333,7 +333,7 @@ class GPILS(MOAgent, MOPolicy):
         )
 
         self.q_state = restored["q_net_state"]
-        self.weight_support = [w for w in restored["M"].values()]
+        self.weight_support = restored["M"]
 
     def _sample_batch_experiences(self):
         return self.replay_buffer.sample(self.batch_size * self.gradient_updates)


### PR DESCRIPTION
In the Jax implementations of GPI-LS, `weight_support` is defined as a list of NumPy arrays. However, when attempting to restore a checkpoint with Orbax, the `.values()` method was used as if the list was a dictionary, which resulted in an `AttributeError: 'list' object has no attribute 'values'`.

This PR fixes the loading of `weight_support` so that the weight list gets loaded directly, fixing the error.